### PR TITLE
Add type annotations to fform in more places

### DIFF
--- a/ext/GraphPPLDistributionsExt.jl
+++ b/ext/GraphPPLDistributionsExt.jl
@@ -31,4 +31,8 @@ end
     end
 end
 
+# Special cases
+GraphPPLDistributionsExt.distributions_ext_input_interfaces(::Type{<:Distributions.InverseWishart}) = GraphPPL.StaticInterfaces((:df, :scale))
+GraphPPLDistributionsExt.distributions_ext_interfaces(::Type{<:Distributions.InverseWishart}) = GraphPPL.StaticInterfaces((:out, :df, :scale))
+
 end

--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -471,7 +471,7 @@ is_constant(properties::VariableNodeProperties) = is_kind(properties, Val(:const
 function Base.show(io::IO, properties::VariableNodeProperties)
     print(io, "name = ", properties.name, ", index = ", properties.index)
     if !isnothing(properties.link)
-        print(io, "(linked to ", node.link, ")")
+        print(io, "(linked to ", properties.link, ")")
     end
 end
 

--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -471,7 +471,7 @@ is_constant(properties::VariableNodeProperties) = is_kind(properties, Val(:const
 function Base.show(io::IO, properties::VariableNodeProperties)
     print(io, "name = ", properties.name, ", index = ", properties.index)
     if !isnothing(properties.link)
-        print(io, "(linked to ", properties.link, ")")
+        print(io, ", linked to ", properties.link)
     end
 end
 


### PR DESCRIPTION
Can you benchmark this @wouterwln , in my benchmarks it shows up to 2x speed up in some cases, which looks suspicious. 
It allocates slightly more in GraphPPL benchmarks, but benchmarks in RxInfer do not show any significant change in the performance nor in memory allocations.