### PR TITLE
Materialize anonymous variables later only if needed

### DIFF
--- a/ext/GraphPPLDistributionsExt.jl
+++ b/ext/GraphPPLDistributionsExt.jl
@@ -31,4 +31,8 @@ end
     end
 end
 
+# Special cases
+GraphPPLDistributionsExt.distributions_ext_input_interfaces(::Type{<:Distributions.InverseWishart}) = GraphPPL.StaticInterfaces((:df, :scale))
+GraphPPLDistributionsExt.distributions_ext_interfaces(::Type{<:Distributions.InverseWishart}) = GraphPPL.StaticInterfaces((:out, :df, :scale))
+
 end

--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -471,7 +471,7 @@ is_constant(properties::VariableNodeProperties) = is_kind(properties, Val(:const
 function Base.show(io::IO, properties::VariableNodeProperties)
     print(io, "name = ", properties.name, ", index = ", properties.index)
     if !isnothing(properties.link)
-        print(io, "(linked to ", node.link, ")")
+        print(io, "(linked to ", properties.link, ")")
     end
 end
 

--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -471,7 +471,7 @@ is_constant(properties::VariableNodeProperties) = is_kind(properties, Val(:const
 function Base.show(io::IO, properties::VariableNodeProperties)
     print(io, "name = ", properties.name, ", index = ", properties.index)
     if !isnothing(properties.link)
-        print(io, "(linked to ", properties.link, ")")
+        print(io, ", linked to ", properties.link)
     end
 end
 


### PR DESCRIPTION
Includes #163 (please merge #163 first)

A silly bug we missed, the fix is pretty easy though. 

~Didn't add the tests yet~ (added), but this is a reproducer

```julia
@model function mv_iid_inverse_wishart_known_mean(y, m, d)
    C ~ InverseWishart(d + 1, diageye(d))

    for i in eachindex(y)
        y[i] ~ MvNormal(μ = m, Σ = C)
    end
end
```


Without this PR the engine creates an anonymous random variable for `d + 1`, but it shouldn't (if `d` is a number and not a data).