### PR TITLE
Add keys for marginal and messages form constraints

### DIFF
--- a/src/plugins/variational_constraints/variational_constraints_engine.jl
+++ b/src/plugins/variational_constraints/variational_constraints_engine.jl
@@ -1,3 +1,9 @@
+
+const VariationalConstraintsFactorizationIndicesKey = NodeDataExtraKey{:factorization_constraint_indices, Tuple}()
+const VariationalConstraintsFactorizationBitSetKey = NodeDataExtraKey{:factorization_constraint_bitset, BoundedBitSetTuple}()
+const VariationalConstraintsMarginalFormConstraintKey = NodeDataExtraKey{:marginal_form_constraint, Any}()
+const VariationalConstraintsMessagesFormConstraintKey = NodeDataExtraKey{:messages_form_constraint, Any}()
+
 """
     CombinedRange{L, R}
 
@@ -189,27 +195,24 @@ Base.:(==)(left::FactorizationConstraint, right::FactorizationConstraint) =
     left.variables == right.variables && left.constraint == right.constraint
 
 """
-    PosteriorFormConstraint{V, F}
-
-A `PosteriorFormConstraint` represents a single functional form constraint in a variational posterior constraint specification. We use type parametrization
+A `MarginalFormConstraint` represents a single functional form constraint in a variational marginal constraint specification. We use type parametrization
 to dispatch on different types of constraints, for example `q(x, y) :: MvNormal` should be treated different from `q(x) :: Normal`.
 """
-struct PosteriorFormConstraint{V, F}
+struct MarginalFormConstraint{V, F}
     variables::V
     constraint::F
 end
 
 """
-    MessageConstraint
-
-A `MessageConstraint` represents a single constraint on the messages in a message passing schema. These constraints closely resemble the `PosteriorFormConstraint` but are used to specify constraints on the messages in a message passing schema.
+A `MessageConstraint` represents a single constraint on the messages in a message passing schema. 
+These constraints closely resemble the `MarginalFormConstraint` but are used to specify constraints on the messages in a message passing schema.
 """
 struct MessageFormConstraint{V, F}
     variables::V
     constraint::F
 end
 
-const MaterializedConstraints = Union{FactorizationConstraint, PosteriorFormConstraint, MessageFormConstraint}
+const MaterializedConstraints = Union{FactorizationConstraint, MarginalFormConstraint, MessageFormConstraint}
 
 getvariables(c::MaterializedConstraints) = c.variables
 getconstraint(c::MaterializedConstraints) = c.constraint
@@ -221,9 +224,9 @@ function Base.show(io::IO, constraint::FactorizationConstraint{V, F} where {V, F
     print(io, join(getconstraint(constraint), ""))
 end
 
-Base.show(io::IO, constraint::PosteriorFormConstraint{V, F} where {V <: AbstractArray, F}) =
+Base.show(io::IO, constraint::MarginalFormConstraint{V, F} where {V <: AbstractArray, F}) =
     print(io, "q(", join(getvariables(constraint), ", "), ") :: ", constraint.constraint)
-Base.show(io::IO, constraint::PosteriorFormConstraint{V, F} where {V <: IndexedVariable, F}) =
+Base.show(io::IO, constraint::MarginalFormConstraint{V, F} where {V <: IndexedVariable, F}) =
     print(io, "q(", getvariables(constraint), ") :: ", constraint.constraint)
 
 """
@@ -273,14 +276,14 @@ An instance of `Constraints` represents a set of constraints to be applied to a 
 """
 struct Constraints{F, P, M, G, S}
     factorization_constraints::F
-    posterior_form_constraints::P
+    marginal_form_constraints::P
     message_form_constraints::M
     general_submodel_constraints::G
     specific_submodel_constraints::S
 end
 
 factorization_constraints(c::Constraints) = c.factorization_constraints
-posterior_form_constraints(c::Constraints) = c.posterior_form_constraints
+marginal_form_constraints(c::Constraints) = c.marginal_form_constraints
 message_form_constraints(c::Constraints) = c.message_form_constraints
 general_submodel_constraints(c::Constraints) = c.general_submodel_constraints
 specific_submodel_constraints(c::Constraints) = c.specific_submodel_constraints
@@ -288,7 +291,7 @@ specific_submodel_constraints(c::Constraints) = c.specific_submodel_constraints
 function Constraints()
     return Constraints(
         Vector{FactorizationConstraint}(),
-        Vector{PosteriorFormConstraint}(),
+        Vector{MarginalFormConstraint}(),
         Vector{MessageFormConstraint}(),
         Dict{Function, GeneralSubModelConstraints}(),
         Dict{FactorID, SpecificSubModelConstraints}()
@@ -319,11 +322,11 @@ function Base.push!(c::Constraints, constraint::FactorizationConstraint{V, F} wh
     push!(c.factorization_constraints, constraint)
 end
 
-function Base.push!(c::Constraints, constraint::PosteriorFormConstraint)
-    if any(issetequal.(Set(getvariables.(c.posterior_form_constraints)), Ref(getvariables(constraint))))
+function Base.push!(c::Constraints, constraint::MarginalFormConstraint)
+    if any(issetequal.(Set(getvariables.(c.marginal_form_constraints)), Ref(getvariables(constraint))))
         error("Cannot add $(constraint) to constraint set as these variables already have a functional form constraint applied.")
     end
-    push!(c.posterior_form_constraints, constraint)
+    push!(c.marginal_form_constraints, constraint)
 end
 
 function Base.push!(c::Constraints, constraint::MessageFormConstraint)
@@ -353,14 +356,14 @@ end
 
 Base.:(==)(left::Constraints, right::Constraints) =
     left.factorization_constraints == right.factorization_constraints &&
-    left.posterior_form_constraints == right.posterior_form_constraints &&
+    left.marginal_form_constraints == right.marginal_form_constraints &&
     left.message_form_constraints == right.message_form_constraints &&
     left.general_submodel_constraints == right.general_submodel_constraints &&
     left.specific_submodel_constraints == right.specific_submodel_constraints
 
 getconstraints(c::Constraints) = Iterators.flatten((
     factorization_constraints(c),
-    posterior_form_constraints(c),
+    marginal_form_constraints(c),
     message_form_constraints(c),
     values(general_submodel_constraints(c)),
     values(specific_submodel_constraints(c))
@@ -532,9 +535,6 @@ end
 function materialize_constraints!(model::Model, node_label::NodeLabel, node_data::NodeData)
     return materialize_constraints!(model, node_label, node_data, getproperties(node_data))
 end
-
-const VariationalConstraintsFactorizationIndicesKey = NodeDataExtraKey{:factorization_constraint_indices, Tuple}()
-const VariationalConstraintsFactorizationBitSetKey = NodeDataExtraKey{:factorization_constraint_bitset, BoundedBitSetTuple}()
 
 function materialize_constraints!(model::Model, node_label::NodeLabel, node_data::NodeData, properties::FactorNodeProperties)
     constraint_bitset = getextra(node_data, VariationalConstraintsFactorizationBitSetKey)
@@ -763,20 +763,20 @@ function convert_to_bitsets(model::Model, node::NodeLabel, neighbors, constraint
 end
 
 function apply_constraints!(
-    model::Model, context::Context, posterior_constraint::PosteriorFormConstraint{T, F} where {T <: IndexedVariable, F}
+    model::Model, context::Context, marginal_constraint::MarginalFormConstraint{T, F} where {T <: IndexedVariable, F}
 )
-    applicable_nodes = unroll(context[getvariables(posterior_constraint)])
+    applicable_nodes = unroll(context[getvariables(marginal_constraint)])
     for node in applicable_nodes
-        if hasextra(model[node], :posterior_form_constraint)
+        if hasextra(model[node], VariationalConstraintsMarginalFormConstraintKey)
             @warn lazy"Node $node already has functional form constraint $(opt[:q]) applied, therefore $constraint_data will not be applied"
         else
-            setextra!(model[node], :posterior_form_constraint, getconstraint(posterior_constraint))
+            setextra!(model[node], VariationalConstraintsMarginalFormConstraintKey, getconstraint(marginal_constraint))
         end
     end
 end
 
 function apply_constraints!(
-    model::Model, context::Context, posterior_constraint::PosteriorFormConstraint{T, F} where {T <: AbstractArray, F}
+    model::Model, context::Context, marginal_constraint::MarginalFormConstraint{T, F} where {T <: AbstractArray, F}
 )
     throw("Not implemented")
 end
@@ -784,10 +784,10 @@ end
 function apply_constraints!(model::Model, context::Context, message_constraint::MessageFormConstraint)
     applicable_nodes = unroll(context[getvariables(message_constraint)])
     for node in applicable_nodes
-        if hasextra(model[node], :message_form_constraint)
+        if hasextra(model[node], VariationalConstraintsMessagesFormConstraintKey)
             @warn lazy"Node $node already has functional form constraint $(opt[:q]) applied, therefore $constraint_data will not be applied"
         else
-            setextra!(model[node], :message_form_constraint, getconstraint(message_constraint))
+            setextra!(model[node], VariationalConstraintsMessagesFormConstraintKey, getconstraint(message_constraint))
         end
     end
 end
@@ -809,7 +809,7 @@ function apply_constraints!(model::Model, context::Context, constraint_set::Cons
     foreach(factorization_constraints(constraint_set)) do fc
         push!(stack, resolve(model, context, fc), context)
     end
-    foreach(posterior_form_constraints(constraint_set)) do ffc
+    foreach(marginal_form_constraints(constraint_set)) do ffc
         apply_constraints!(model, context, ffc)
     end
     foreach(message_form_constraints(constraint_set)) do mc

--- a/src/plugins/variational_constraints/variational_constraints_macro.jl
+++ b/src/plugins/variational_constraints/variational_constraints_macro.jl
@@ -108,11 +108,11 @@ end
 function convert_functionalform_constraints(e::Expr)
     if @capture(e, (q(vars_)::T_))
         return quote
-            push!(__constraints__, GraphPPL.PosteriorFormConstraint($vars, $T))
+            push!(__constraints__, GraphPPL.MarginalFormConstraint($vars, $T))
         end
     elseif @capture(e, (q(vars__)::T_))
         return quote
-            push!(__constraints__, GraphPPL.PosteriorFormConstraint($(Expr(:tuple, vars...)), $T))
+            push!(__constraints__, GraphPPL.MarginalFormConstraint($(Expr(:tuple, vars...)), $T))
         end
     else
         return e

--- a/test/plugins/variational_constraints/variational_constraints_engine_tests.jl
+++ b/test/plugins/variational_constraints/variational_constraints_engine_tests.jl
@@ -321,7 +321,7 @@ end
         Constraints,
         FactorizationConstraint,
         FactorizationConstraintEntry,
-        PosteriorFormConstraint,
+        MarginalFormConstraint,
         MessageFormConstraint,
         SpecificSubModelConstraints,
         GeneralSubModelConstraints,
@@ -348,17 +348,17 @@ end
     )
     @test_throws ErrorException push!(constraints, constraint)
 
-    # Test 2: Test push! with PosteriorFormConstraint
-    constraint = PosteriorFormConstraint(IndexedVariable(:x, nothing), Normal)
+    # Test 2: Test push! with MarginalFormConstraint
+    constraint = MarginalFormConstraint(IndexedVariable(:x, nothing), Normal)
     push!(constraints, constraint)
     @test_throws ErrorException push!(constraints, constraint)
-    constraint = PosteriorFormConstraint((IndexedVariable(:x, nothing), IndexedVariable(:y, nothing)), Normal)
+    constraint = MarginalFormConstraint((IndexedVariable(:x, nothing), IndexedVariable(:y, nothing)), Normal)
     push!(constraints, constraint)
     @test_throws ErrorException push!(constraints, constraint)
-    constraint = PosteriorFormConstraint(IndexedVariable(:x, 1), Normal)
+    constraint = MarginalFormConstraint(IndexedVariable(:x, 1), Normal)
     push!(constraints, constraint)
     @test_throws ErrorException push!(constraints, constraint)
-    constraint = PosteriorFormConstraint([IndexedVariable(:x, 1), IndexedVariable(:y, 1)], Normal)
+    constraint = MarginalFormConstraint([IndexedVariable(:x, 1), IndexedVariable(:y, 1)], Normal)
     push!(constraints, constraint)
     @test_throws ErrorException push!(constraints, constraint)
 
@@ -388,7 +388,7 @@ end
         SpecificSubModelConstraints,
         FactorizationConstraint,
         FactorizationConstraintEntry,
-        PosteriorFormConstraint,
+        MarginalFormConstraint,
         MessageFormConstraint,
         getconstraint,
         Constraints,
@@ -413,11 +413,11 @@ end
     ],)
     @test_throws MethodError push!(constraints, "string")
 
-    # Test 2: Test push! with PosteriorFormConstraint
+    # Test 2: Test push! with MarginalFormConstraint
     constraints = GeneralSubModelConstraints(gcv)
-    constraint = PosteriorFormConstraint(IndexedVariable(:x, nothing), Normal)
+    constraint = MarginalFormConstraint(IndexedVariable(:x, nothing), Normal)
     push!(constraints, constraint)
-    @test getconstraint(constraints) == Constraints([PosteriorFormConstraint(IndexedVariable(:x, nothing), Normal)],)
+    @test getconstraint(constraints) == Constraints([MarginalFormConstraint(IndexedVariable(:x, nothing), Normal)],)
     @test_throws MethodError push!(constraints, "string")
 
     # Test 3: Test push! with MessageFormConstraint
@@ -442,11 +442,11 @@ end
     ],)
     @test_throws MethodError push!(constraints, "string")
 
-    # Test 5: Test push! with PosteriorFormConstraint
+    # Test 5: Test push! with MarginalFormConstraint
     constraints = GeneralSubModelConstraints(gcv)
-    constraint = PosteriorFormConstraint(IndexedVariable(:x, nothing), Normal)
+    constraint = MarginalFormConstraint(IndexedVariable(:x, nothing), Normal)
     push!(constraints, constraint)
-    @test getconstraint(constraints) == Constraints([PosteriorFormConstraint(IndexedVariable(:x, nothing), Normal)],)
+    @test getconstraint(constraints) == Constraints([MarginalFormConstraint(IndexedVariable(:x, nothing), Normal)],)
     @test_throws MethodError push!(constraints, "string")
 
     # Test 6: Test push! with MessageFormConstraint
@@ -510,8 +510,8 @@ end
     end
 end
 
-@testitem "Application of PosteriorFormConstraint" begin
-    import GraphPPL: create_model, PosteriorFormConstraint, IndexedVariable, apply_constraints!, getextra, hasextra
+@testitem "Application of MarginalFormConstraint" begin
+    import GraphPPL: create_model, MarginalFormConstraint, IndexedVariable, apply_constraints!, getextra, hasextra, VariationalConstraintsMarginalFormConstraintKey
 
     include("../../testutils.jl")
 
@@ -519,44 +519,44 @@ end
 
     struct ArbitraryFunctionalFormConstraint end
 
-    # Test saving of PosteriorFormConstraint in single variable
+    # Test saving of MarginalFormConstraint in single variable
     model = create_model(simple_model())
     context = GraphPPL.getcontext(model)
-    constraint = PosteriorFormConstraint(IndexedVariable(:x, nothing), ArbitraryFunctionalFormConstraint())
+    constraint = MarginalFormConstraint(IndexedVariable(:x, nothing), ArbitraryFunctionalFormConstraint())
     apply_constraints!(model, context, constraint)
     for node in filter(GraphPPL.as_variable(:x), model)
-        @test getextra(model[node], :posterior_form_constraint) == ArbitraryFunctionalFormConstraint()
+        @test getextra(model[node], VariationalConstraintsMarginalFormConstraintKey) == ArbitraryFunctionalFormConstraint()
     end
 
-    # Test saving of PosteriorFormConstraint in multiple variables
+    # Test saving of MarginalFormConstraint in multiple variables
     model = create_model(vector_model())
     context = GraphPPL.getcontext(model)
-    constraint = PosteriorFormConstraint(IndexedVariable(:x, nothing), ArbitraryFunctionalFormConstraint())
+    constraint = MarginalFormConstraint(IndexedVariable(:x, nothing), ArbitraryFunctionalFormConstraint())
     apply_constraints!(model, context, constraint)
     for node in filter(GraphPPL.as_variable(:x), model)
-        @test getextra(model[node], :posterior_form_constraint) == ArbitraryFunctionalFormConstraint()
+        @test getextra(model[node], VariationalConstraintsMarginalFormConstraintKey) == ArbitraryFunctionalFormConstraint()
     end
     for node in filter(GraphPPL.as_variable(:y), model)
-        @test !hasextra(model[node], :posterior_form_constraint)
+        @test !hasextra(model[node], VariationalConstraintsMarginalFormConstraintKey)
     end
 
-    # Test saving of PosteriorFormConstraint in single variable in array
+    # Test saving of MarginalFormConstraint in single variable in array
     model = create_model(vector_model())
     context = GraphPPL.getcontext(model)
-    constraint = PosteriorFormConstraint(IndexedVariable(:x, 1), ArbitraryFunctionalFormConstraint())
+    constraint = MarginalFormConstraint(IndexedVariable(:x, 1), ArbitraryFunctionalFormConstraint())
     apply_constraints!(model, context, constraint)
     applied_node = context[:x][1]
     for node in filter(GraphPPL.as_variable(:x), model)
         if node == applied_node
-            @test getextra(model[node], :posterior_form_constraint) == ArbitraryFunctionalFormConstraint()
+            @test getextra(model[node], VariationalConstraintsMarginalFormConstraintKey) == ArbitraryFunctionalFormConstraint()
         else
-            @test !hasextra(model[node], :posterior_form_constraint)
+            @test !hasextra(model[node], VariationalConstraintsMarginalFormConstraintKey)
         end
     end
 end
 
 @testitem "Application of MessageFormConstraint" begin
-    import GraphPPL: create_model, MessageFormConstraint, IndexedVariable, apply_constraints!, hasextra, getextra
+    import GraphPPL: create_model, MessageFormConstraint, IndexedVariable, apply_constraints!, hasextra, getextra, VariationalConstraintsMessagesFormConstraintKey
 
     include("../../testutils.jl")
 
@@ -570,7 +570,7 @@ end
     constraint = MessageFormConstraint(IndexedVariable(:x, nothing), ArbitraryMessageFormConstraint())
     node = first(filter(GraphPPL.as_variable(:x), model))
     apply_constraints!(model, context, constraint)
-    @test getextra(model[node], :message_form_constraint) == ArbitraryMessageFormConstraint()
+    @test getextra(model[node], VariationalConstraintsMessagesFormConstraintKey) == ArbitraryMessageFormConstraint()
 
     # Test saving of MessageFormConstraint in multiple variables
     model = create_model(vector_model())
@@ -578,10 +578,10 @@ end
     constraint = MessageFormConstraint(IndexedVariable(:x, nothing), ArbitraryMessageFormConstraint())
     apply_constraints!(model, context, constraint)
     for node in filter(GraphPPL.as_variable(:x), model)
-        @test getextra(model[node], :message_form_constraint) == ArbitraryMessageFormConstraint()
+        @test getextra(model[node], VariationalConstraintsMessagesFormConstraintKey) == ArbitraryMessageFormConstraint()
     end
     for node in filter(GraphPPL.as_variable(:y), model)
-        @test !hasextra(model[node], :message_form_constraint)
+        @test !hasextra(model[node], VariationalConstraintsMessagesFormConstraintKey)
     end
 
     # Test saving of MessageFormConstraint in single variable in array
@@ -592,9 +592,9 @@ end
     applied_node = context[:x][1]
     for node in filter(GraphPPL.as_variable(:x), model)
         if node == applied_node
-            @test getextra(model[node], :message_form_constraint) == ArbitraryMessageFormConstraint()
+            @test getextra(model[node], VariationalConstraintsMessagesFormConstraintKey) == ArbitraryMessageFormConstraint()
         else
-            @test !hasextra(model[node], :message_form_constraint)
+            @test !hasextra(model[node], VariationalConstraintsMessagesFormConstraintKey)
         end
     end
 end

--- a/test/plugins/variational_constraints/variational_constraints_macro_tests.jl
+++ b/test/plugins/variational_constraints/variational_constraints_macro_tests.jl
@@ -464,7 +464,7 @@ end
         q(GraphPPL.IndexedVariable(:x, nothing))::PointMass
     end
     output = quote
-        push!(__constraints__, GraphPPL.PosteriorFormConstraint(GraphPPL.IndexedVariable(:x, nothing), PointMass))
+        push!(__constraints__, GraphPPL.MarginalFormConstraint(GraphPPL.IndexedVariable(:x, nothing), PointMass))
     end
     @test_expression_generating apply_pipeline(input, convert_functionalform_constraints) output
 
@@ -475,7 +475,7 @@ end
     output = quote
         push!(
             __constraints__,
-            GraphPPL.PosteriorFormConstraint((GraphPPL.IndexedVariable(:x, nothing), GraphPPL.IndexedVariable(:y, nothing)), PointMass)
+            GraphPPL.MarginalFormConstraint((GraphPPL.IndexedVariable(:x, nothing), GraphPPL.IndexedVariable(:y, nothing)), PointMass)
         )
     end
     @test_expression_generating apply_pipeline(input, convert_functionalform_constraints) output
@@ -499,13 +499,13 @@ end
     output = quote
         push!(
             __constraints__,
-            GraphPPL.PosteriorFormConstraint((GraphPPL.IndexedVariable(:x, nothing), GraphPPL.IndexedVariable(:y, nothing)), PointMass)
+            GraphPPL.MarginalFormConstraint((GraphPPL.IndexedVariable(:x, nothing), GraphPPL.IndexedVariable(:y, nothing)), PointMass)
         )
         let __outer_constraints__ = __constraints__
             let __constraints__ = GraphPPL.GeneralSubModelConstraints(submodel)
                 push!(
                     __constraints__,
-                    GraphPPL.PosteriorFormConstraint(
+                    GraphPPL.MarginalFormConstraint(
                         (GraphPPL.IndexedVariable(:x, nothing), GraphPPL.IndexedVariable(:y, nothing)), PointMass
                     )
                 )
@@ -513,7 +513,7 @@ end
                     let __constraints__ = GraphPPL.GeneralSubModelConstraints(subsubmodel)
                         push!(
                             __constraints__,
-                            GraphPPL.PosteriorFormConstraint(
+                            GraphPPL.MarginalFormConstraint(
                                 (GraphPPL.IndexedVariable(:x, nothing), GraphPPL.IndexedVariable(:y, nothing)), PointMass
                             )
                         )
@@ -593,7 +593,7 @@ end
     end
     output = quote
         __constraints__ = GraphPPL.Constraints()
-        push!(__constraints__, GraphPPL.PosteriorFormConstraint(GraphPPL.IndexedVariable(:x, nothing), Normal))
+        push!(__constraints__, GraphPPL.MarginalFormConstraint(GraphPPL.IndexedVariable(:x, nothing), Normal))
         let __outer_constraints__ = __constraints__
             let __constraints__ = GraphPPL.GeneralSubModelConstraints(second_submodel)
                 push!(

--- a/test/plugins/variational_constraints/variational_constraints_tests.jl
+++ b/test/plugins/variational_constraints/variational_constraints_tests.jl
@@ -578,7 +578,9 @@ end
         as_variable,
         PluginsCollection,
         VariationalConstraintsPlugin,
-        with_plugins
+        with_plugins,
+        VariationalConstraintsMarginalFormConstraintKey,
+        VariationalConstraintsMessagesFormConstraintKey
 
     include("../../testutils.jl")
 
@@ -607,14 +609,14 @@ end
         @test length(zvariables) === 1
         @test length(xvariables) === 1
         @test length(yvariables) === 1
-        @test hasextra(first(zvariables), :posterior_form_constraint)
-        @test getextra(first(zvariables), :posterior_form_constraint) === SomeArbitraryFormConstraint1()
-        @test !hasextra(first(zvariables), :message_form_constraint)
+        @test hasextra(first(zvariables), VariationalConstraintsMarginalFormConstraintKey)
+        @test getextra(first(zvariables), VariationalConstraintsMarginalFormConstraintKey) === SomeArbitraryFormConstraint1()
+        @test !hasextra(first(zvariables), VariationalConstraintsMessagesFormConstraintKey)
 
-        @test !hasextra(first(xvariables), :posterior_form_constraint)
-        @test !hasextra(first(xvariables), :message_form_constraint)
-        @test !hasextra(first(yvariables), :posterior_form_constraint)
-        @test !hasextra(first(yvariables), :message_form_constraint)
+        @test !hasextra(first(xvariables), VariationalConstraintsMarginalFormConstraintKey)
+        @test !hasextra(first(xvariables), VariationalConstraintsMessagesFormConstraintKey)
+        @test !hasextra(first(yvariables), VariationalConstraintsMarginalFormConstraintKey)
+        @test !hasextra(first(yvariables), VariationalConstraintsMessagesFormConstraintKey)
     end
 
     @testset "Messages functional form constraints" begin
@@ -633,14 +635,14 @@ end
         @test length(zvariables) === 1
         @test length(xvariables) === 1
         @test length(yvariables) === 1
-        @test hasextra(first(zvariables), :message_form_constraint)
-        @test getextra(first(zvariables), :message_form_constraint) === SomeArbitraryFormConstraint2()
-        @test !hasextra(first(zvariables), :posterior_form_constraint)
+        @test hasextra(first(zvariables), VariationalConstraintsMessagesFormConstraintKey)
+        @test getextra(first(zvariables), VariationalConstraintsMessagesFormConstraintKey) === SomeArbitraryFormConstraint2()
+        @test !hasextra(first(zvariables), VariationalConstraintsMarginalFormConstraintKey)
 
-        @test !hasextra(first(xvariables), :posterior_form_constraint)
-        @test !hasextra(first(xvariables), :message_form_constraint)
-        @test !hasextra(first(yvariables), :posterior_form_constraint)
-        @test !hasextra(first(yvariables), :message_form_constraint)
+        @test !hasextra(first(xvariables), VariationalConstraintsMarginalFormConstraintKey)
+        @test !hasextra(first(xvariables), VariationalConstraintsMessagesFormConstraintKey)
+        @test !hasextra(first(yvariables), VariationalConstraintsMarginalFormConstraintKey)
+        @test !hasextra(first(yvariables), VariationalConstraintsMessagesFormConstraintKey)
     end
 
     @testset "Both posteriors and messages functional form constraints" begin
@@ -660,20 +662,31 @@ end
         @test length(zvariables) === 1
         @test length(xvariables) === 1
         @test length(yvariables) === 1
-        @test hasextra(first(zvariables), :posterior_form_constraint)
-        @test getextra(first(zvariables), :posterior_form_constraint) === SomeArbitraryFormConstraint1()
-        @test hasextra(first(zvariables), :message_form_constraint)
-        @test getextra(first(zvariables), :message_form_constraint) === SomeArbitraryFormConstraint2()
+        @test hasextra(first(zvariables), VariationalConstraintsMarginalFormConstraintKey)
+        @test getextra(first(zvariables), VariationalConstraintsMarginalFormConstraintKey) === SomeArbitraryFormConstraint1()
+        @test hasextra(first(zvariables), VariationalConstraintsMessagesFormConstraintKey)
+        @test getextra(first(zvariables), VariationalConstraintsMessagesFormConstraintKey) === SomeArbitraryFormConstraint2()
 
-        @test !hasextra(first(xvariables), :posterior_form_constraint)
-        @test !hasextra(first(xvariables), :message_form_constraint)
-        @test !hasextra(first(yvariables), :posterior_form_constraint)
-        @test !hasextra(first(yvariables), :message_form_constraint)
+        @test !hasextra(first(xvariables), VariationalConstraintsMarginalFormConstraintKey)
+        @test !hasextra(first(xvariables), VariationalConstraintsMessagesFormConstraintKey)
+        @test !hasextra(first(yvariables), VariationalConstraintsMarginalFormConstraintKey)
+        @test !hasextra(first(yvariables), VariationalConstraintsMessagesFormConstraintKey)
     end
 end
 
 @testitem "@constraints macro pipeline" begin
-    import GraphPPL: create_model, with_plugins, PluginsCollection, VariationalConstraintsPlugin, getname, getextra, hasextra, with_plugins
+    import GraphPPL:
+        create_model,
+        with_plugins,
+        PluginsCollection,
+        VariationalConstraintsPlugin,
+        getname,
+        getextra,
+        hasextra,
+        with_plugins,
+        VariationalConstraintsMarginalFormConstraintKey,
+        VariationalConstraintsMessagesFormConstraintKey,
+        VariationalConstraintsFactorizationIndicesKey
 
     include("../../testutils.jl")
 
@@ -690,19 +703,19 @@ end
     ctx = GraphPPL.getcontext(model)
 
     for node in filter(GraphPPL.as_variable(:x), model)
-        @test getextra(model[node], :posterior_form_constraint) == NormalMeanVariance()
-        @test !hasextra(model[node], :message_form_constraint)
+        @test getextra(model[node], VariationalConstraintsMarginalFormConstraintKey) == NormalMeanVariance()
+        @test !hasextra(model[node], VariationalConstraintsMessagesFormConstraintKey)
     end
     for node in filter(GraphPPL.as_variable(:y), model)
-        @test !hasextra(model[node], :posterior_form_constraint)
-        @test getextra(model[node], :message_form_constraint) == NormalMeanVariance()
+        @test !hasextra(model[node], VariationalConstraintsMarginalFormConstraintKey)
+        @test getextra(model[node], VariationalConstraintsMessagesFormConstraintKey) == NormalMeanVariance()
     end
     for node in filter(GraphPPL.as_variable(:z), model)
-        @test !hasextra(model[node], :posterior_form_constraint)
-        @test !hasextra(model[node], :message_form_constraint)
+        @test !hasextra(model[node], VariationalConstraintsMarginalFormConstraintKey)
+        @test !hasextra(model[node], VariationalConstraintsMessagesFormConstraintKey)
     end
-    @test Tuple.(getextra(model[ctx[NormalMeanVariance, 1]], :factorization_constraint_indices)) == ((1,), (2,), (3,))
-    @test Tuple.(getextra(model[ctx[NormalMeanVariance, 2]], :factorization_constraint_indices)) == ((1, 2), (3,))
+    @test Tuple.(getextra(model[ctx[NormalMeanVariance, 1]], VariationalConstraintsFactorizationIndicesKey)) == ((1,), (2,), (3,))
+    @test Tuple.(getextra(model[ctx[NormalMeanVariance, 2]], VariationalConstraintsFactorizationIndicesKey)) == ((1, 2), (3,))
 
     # Test constriants macro with nested model
     constraints = @constraints begin
@@ -715,21 +728,21 @@ end
     model = create_model(with_plugins(outer(), PluginsCollection(VariationalConstraintsPlugin(constraints))))
     ctx = GraphPPL.getcontext(model)
 
-    @test hasextra(model[ctx[:w][1]], :posterior_form_constraint) === false
-    @test hasextra(model[ctx[:w][2]], :posterior_form_constraint) === false
-    @test hasextra(model[ctx[:w][3]], :posterior_form_constraint) === false
-    @test hasextra(model[ctx[:w][4]], :posterior_form_constraint) === false
-    @test hasextra(model[ctx[:w][5]], :posterior_form_constraint) === false
+    @test hasextra(model[ctx[:w][1]], VariationalConstraintsMarginalFormConstraintKey) === false
+    @test hasextra(model[ctx[:w][2]], VariationalConstraintsMarginalFormConstraintKey) === false
+    @test hasextra(model[ctx[:w][3]], VariationalConstraintsMarginalFormConstraintKey) === false
+    @test hasextra(model[ctx[:w][4]], VariationalConstraintsMarginalFormConstraintKey) === false
+    @test hasextra(model[ctx[:w][5]], VariationalConstraintsMarginalFormConstraintKey) === false
 
-    @test hasextra(model[ctx[:w][1]], :message_form_constraint) === false
-    @test getextra(model[ctx[:w][2]], :message_form_constraint) === NormalMeanVariance()
-    @test getextra(model[ctx[:w][3]], :message_form_constraint) === NormalMeanVariance()
-    @test hasextra(model[ctx[:w][4]], :message_form_constraint) === false
-    @test hasextra(model[ctx[:w][5]], :message_form_constraint) === false
+    @test hasextra(model[ctx[:w][1]], VariationalConstraintsMessagesFormConstraintKey) === false
+    @test getextra(model[ctx[:w][2]], VariationalConstraintsMessagesFormConstraintKey) === NormalMeanVariance()
+    @test getextra(model[ctx[:w][3]], VariationalConstraintsMessagesFormConstraintKey) === NormalMeanVariance()
+    @test hasextra(model[ctx[:w][4]], VariationalConstraintsMessagesFormConstraintKey) === false
+    @test hasextra(model[ctx[:w][5]], VariationalConstraintsMessagesFormConstraintKey) === false
 
-    @test getextra(model[ctx[:y]], :posterior_form_constraint) == NormalMeanVariance()
+    @test getextra(model[ctx[:y]], VariationalConstraintsMarginalFormConstraintKey) == NormalMeanVariance()
     for node in filter(GraphPPL.as_node(NormalMeanVariance) & GraphPPL.as_context(inner_inner), model)
-        @test Tuple.(getextra(model[node], :factorization_constraint_indices)) == ((1,), (2, 3))
+        @test Tuple.(getextra(model[node], VariationalConstraintsFactorizationIndicesKey)) == ((1,), (2, 3))
     end
 
     # Test with specifying specific submodel
@@ -741,9 +754,11 @@ end
     model = create_model(with_plugins(parent_model(), PluginsCollection(VariationalConstraintsPlugin(constraints))))
     ctx = GraphPPL.getcontext(model)
 
-    @test Tuple.(getextra(model[ctx[child_model, 1][NormalMeanVariance, 1]], :factorization_constraint_indices)) == ((1, 2), (3,))
+    @test Tuple.(getextra(model[ctx[child_model, 1][NormalMeanVariance, 1]], VariationalConstraintsFactorizationIndicesKey)) ==
+        ((1, 2), (3,))
     for i in 2:99
-        @test Tuple.(getextra(model[ctx[child_model, i][NormalMeanVariance, 1]], :factorization_constraint_indices)) == ((1, 2, 3),)
+        @test Tuple.(getextra(model[ctx[child_model, i][NormalMeanVariance, 1]], VariationalConstraintsFactorizationIndicesKey)) ==
+            ((1, 2, 3),)
     end
 
     # Test with specifying general submodel
@@ -755,9 +770,9 @@ end
     model = create_model(with_plugins(parent_model(), PluginsCollection(VariationalConstraintsPlugin(constraints))))
     ctx = GraphPPL.getcontext(model)
 
-    @test Tuple.(getextra(model[ctx[child_model, 1][NormalMeanVariance, 1]], :factorization_constraint_indices)) == ((1, 2), (3,))
+    @test Tuple.(getextra(model[ctx[child_model, 1][NormalMeanVariance, 1]], VariationalConstraintsFactorizationIndicesKey)) == ((1, 2), (3,))
     for node in filter(GraphPPL.as_node(NormalMeanVariance) & GraphPPL.as_context(child_model), model)
-        @test Tuple.(getextra(model[node], :factorization_constraint_indices)) == ((1, 2), (3,))
+        @test Tuple.(getextra(model[node], VariationalConstraintsFactorizationIndicesKey)) == ((1, 2), (3,))
     end
 
     # Test with ambiguous constraints
@@ -968,7 +983,7 @@ end
 
     # BetheFactorization uses `default_constraints` for `contains_default_constraints`
     # So it is not tested here
-    for model_fform in setdiff(Set(ModelsInTheZooWithoutArguments), Set([ contains_default_constraints ]))
+    for model_fform in setdiff(Set(ModelsInTheZooWithoutArguments), Set([contains_default_constraints]))
         model = create_model(
             with_plugins(model_fform(), GraphPPL.PluginsCollection(GraphPPL.VariationalConstraintsPlugin(BetheFactorization())))
         )


### PR DESCRIPTION
This PR adds constant keys for marginal and messages form constraints. It also renames `posterior` -> `marginal` back after discussion with Ismail.