### PR TITLE
Fix invalid deterministic fform evaluation 

### DIFF
--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -882,7 +882,6 @@ check_variate_compatability(node::ResizableArray{NodeLabel, V, N}, index::NTuple
 check_variate_compatability(node::ResizableArray{NodeLabel, V, N}, index::Vararg{Int, M}) where {V, N, M} =
     error("Index of length $(length(index)) not possible for $N-dimensional vector of random variables")
 
-
 check_variate_compatability(node::ResizableArray{NodeLabel, V, N}, index::Nothing) where {V, N} =
     error("Cannot call vector of random variables on the left-hand-side by an unindexed statement")
 
@@ -1464,7 +1463,7 @@ make_node!(
     make_node!(contains_nodelabel(rhs_interfaces), atomic, deterministic, model, ctx, options, fform, lhs_interface, rhs_interfaces)
 
 # If the node should not be materialized (if it's Atomic, Deterministic and contains no NodeLabel objects), we return the `fform` evaluated at the interfaces
-# This works only if the `lhs_interface` is `AnonymousVariable`
+# This works only if the `lhs_interface` is `AnonymousVariable` (or the corresponding `ProxyLabel` with `AnonymousVariable` as the proxied variable)
 __evaluate_fform(fform::F, args::Tuple) where {F} = fform(args...)
 __evaluate_fform(fform::F, args::NamedTuple) where {F} = fform(; args...)
 __evaluate_fform(fform::F, args::MixedArguments) where {F} = fform(args.args...; args.kwargs...)
@@ -1477,7 +1476,7 @@ make_node!(
     ctx::Context,
     options::NodeCreationOptions,
     fform::F,
-    lhs_interface::AnonymousVariable,
+    lhs_interface::Union{AnonymousVariable, ProxyLabel{<:T, <:AnonymousVariable} where {T}},
     rhs_interfaces::Union{Tuple, NamedTuple, MixedArguments}
 ) where {F} = (nothing, __evaluate_fform(fform, rhs_interfaces))
 

--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -1458,18 +1458,11 @@ make_node!(
 ) where {F} =
     make_node!(contains_nodelabel(rhs_interfaces), atomic, deterministic, model, ctx, options, fform, lhs_interface, rhs_interfaces)
 
-# If the node should not be materialized (if it's Atomic, Deterministic and contains no NodeLabel objects), we return the function evaluated at the interfaces
-make_node!(
-    ::False,
-    ::Atomic,
-    ::Deterministic,
-    model::Model,
-    ctx::Context,
-    options::NodeCreationOptions,
-    fform::F,
-    lhs_interface,
-    rhs_interfaces::Tuple
-) where {F} = (nothing, fform(rhs_interfaces...))
+# If the node should not be materialized (if it's Atomic, Deterministic and contains no NodeLabel objects), we return the `fform` evaluated at the interfaces
+# This works only if the `lhs_interface` is `AnonymousVariable`
+__evaluate_fform(fform::F, args::Tuple) where {F} = fform(args...)
+__evaluate_fform(fform::F, args::NamedTuple) where {F} = fform(; args...)
+__evaluate_fform(fform::F, args::MixedArguments) where {F} = fform(args.args...; args.kwargs...)
 
 make_node!(
     ::False,
@@ -1479,10 +1472,12 @@ make_node!(
     ctx::Context,
     options::NodeCreationOptions,
     fform::F,
-    lhs_interface,
-    rhs_interfaces::NamedTuple
-) where {F} = (nothing, fform(; rhs_interfaces...))
+    lhs_interface::AnonymousVariable,
+    rhs_interfaces::Union{Tuple, NamedTuple, MixedArguments}
+) where {F} = (nothing, __evaluate_fform(fform, rhs_interfaces))
 
+# In case if the `lhs_interface` is something else we throw an error saying that `fform` cannot be instantiated since
+# arguments are not stochastic and the `fform` is not stochastic either, thus the usage of `~` is invalid
 make_node!(
     ::False,
     ::Atomic,
@@ -1492,8 +1487,8 @@ make_node!(
     options::NodeCreationOptions,
     fform::F,
     lhs_interface,
-    rhs_interfaces::MixedArguments
-) where {F} = (nothing, fform(rhs_interfaces.args...; rhs_interfaces.kwargs...))
+    rhs_interfaces::Union{Tuple, NamedTuple, MixedArguments}
+) where {F} = error("`$(fform)` cannot be used as a factor node. Both the arguments and the node are not stochastic.")
 
 # If a node is Stochastic, we always materialize.
 make_node!(

--- a/test/graph_engine_tests.jl
+++ b/test/graph_engine_tests.jl
@@ -1838,6 +1838,7 @@ end
         make_node!,
         create_model,
         getorcreate!,
+        AnonymousVariable,
         ProxyLabel,
         getname,
         label_for,
@@ -1855,10 +1856,15 @@ end
     model = create_test_model()
     ctx = getcontext(model)
     options = NodeCreationOptions()
-    x = getorcreate!(model, ctx, :x, nothing)
+    x = AnonymousVariable(model, ctx)
     @test make_node!(model, ctx, options, +, x, (1, 1)) == (nothing, 2)
     @test make_node!(model, ctx, options, sin, x, (0,)) == (nothing, 0)
-    @test nv(model) == 1
+    @test nv(model) == 0
+
+    x = ProxyLabel(:proxy, nothing, AnonymousVariable(model, ctx))
+    @test make_node!(model, ctx, options, +, x, (1, 1)) == (nothing, 2)
+    @test make_node!(model, ctx, options, sin, x, (0,)) == (nothing, 0)
+    @test nv(model) == 0
 
     # Test 2: Stochastic atomic call returns a new node id
     node_id, _ = make_node!(model, ctx, options, Normal, x, (μ = 0, σ = 1))
@@ -1947,7 +1953,7 @@ end
     model = create_test_model()
     ctx = getcontext(model)
     options = NodeCreationOptions()
-    out = getorcreate!(model, ctx, :out, nothing)
+    out = AnonymousVariable(model, ctx)
     @test make_node!(model, ctx, options, abc, out, (a = 1, b = 2)) == (nothing, 3)
 
     # Test 11: Deterministic node with mixed arguments
@@ -1957,7 +1963,7 @@ end
     model = create_test_model()
     ctx = getcontext(model)
     options = NodeCreationOptions()
-    out = getorcreate!(model, ctx, :out, nothing)
+    out = AnonymousVariable(model, ctx)
     @test make_node!(model, ctx, options, abc, out, MixedArguments((2,), (b = 2,))) == (nothing, 4)
 
     # Test 12: Deterministic node with mixed arguments that has to be materialized should throw error


### PR DESCRIPTION
This PR fixes cases where deterministic evaluation was invalid. E.g. in cases like
```julia
@model function broken_beta_bernoulli(y)
        θ ~ Matrix([1.0 0.0; 0.0 1.0])
        for i in eachindex(y)
            y[i] ~ Bernoulli(θ)
        end
    end
```
The `Matrix([1.0 0.0; 0.0 1.0])` was evaluated and discarded. This PR fixes that, by allowing the evaluation of rhs only if the lhs is an anonymous variable. Such that this is still possible 
```julia
θ ~ MvNormal(mean = zeros(2), covariance = Matrix([1.0 0.0; 0.0 1.0]))
```