### PR TITLE
Allow passing of arbitrary vectors in submodels

### DIFF
--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -852,6 +852,12 @@ add_to_child_context(child_context::Context, name_in_child::Symbol, object_in_pa
 add_to_child_context(child_context::Context, name_in_child::Symbol, object_in_parent::ResizableArray{NodeLabel, V, N}) where {V, N} =
     set!(child_context.tensor_variables, name_in_child, object_in_parent)
 
+add_to_child_context(child_context::Context, name_in_child::Symbol, object_in_parent::AbstractArray{NodeLabel, 1})  =
+    set!(child_context.vector_variables, name_in_child, ResizableArray(object_in_parent))
+
+add_to_child_context(child_context::Context, name_in_child::Symbol, object_in_parent::AbstractArray{NodeLabel, N}) where {N} =
+    throw(NotImplementedError("Currently it's not possible to pass a custom made matrix of random variables to a child context. Maybe you can redefine your model to implicitly create the matrix and pass it like that?"))
+
 add_to_child_context(child_context::Context, name_in_child::Symbol, object_in_parent::ProxyLabel) =
     set!(child_context.proxies, name_in_child, object_in_parent)
 
@@ -877,13 +883,13 @@ check_variate_compatability(node::NodeLabel, index) =
 check_variate_compatability(label::GraphPPL.ProxyLabel, index) = check_variate_compatability(unroll(label), index)
 check_variate_compatability(label::GraphPPL.ProxyLabel, index...) = check_variate_compatability(unroll(label), index)
 
-check_variate_compatability(node::ResizableArray{NodeLabel, V, N}, index::Vararg{Int, N}) where {V, N} = isassigned(node, index...)
-check_variate_compatability(node::ResizableArray{NodeLabel, V, N}, index::NTuple{N, Int}) where {V, N} = isassigned(node, index...)
-check_variate_compatability(node::ResizableArray{NodeLabel, V, N}, index::Vararg{Int, M}) where {V, N, M} =
+check_variate_compatability(node::AbstractArray{NodeLabel, N}, index::Vararg{Int, N}) where {N} = isassigned(node, index...)
+check_variate_compatability(node::AbstractArray{NodeLabel, N}, index::NTuple{N, Int}) where {N} = isassigned(node, index...)
+check_variate_compatability(node::AbstractArray{NodeLabel, N}, index::Vararg{Int, M}) where {N, M} =
     error("Index of length $(length(index)) not possible for $N-dimensional vector of random variables")
 
 
-check_variate_compatability(node::ResizableArray{NodeLabel, V, N}, index::Nothing) where {V, N} =
+check_variate_compatability(node::AbstractArray{NodeLabel, N}, index::Nothing) where {N} =
     error("Cannot call vector of random variables on the left-hand-side by an unindexed statement")
 
 """

--- a/src/plugins/variational_constraints/variational_constraints_engine.jl
+++ b/src/plugins/variational_constraints/variational_constraints_engine.jl
@@ -735,12 +735,15 @@ resolve(model::Model, context::Context, variable::IndexedVariable{CombinedRange{
     throw(UnresolvableFactorizationConstraintError("Cannot resolve factorization constraint for a combined range of dimension > 2."))
 
 function resolve(model::Model, context::Context, variable::IndexedVariable{<:CombinedRange})
-    global_label = unroll(context[getname(variable)])[firstindex(index(variable)):lastindex(index(variable))]
+    global_label = view(unroll(context[getname(variable)]), firstindex(index(variable)):lastindex(index(variable)))
     return __resolve(model, global_label)
 end
 
 function resolve(model::Model, context::Context, constraint::FactorizationConstraint)
     vfiltered = filter(variable -> haskey(context, getname(variable)), getvariables(constraint))
+    if length(vfiltered) != length(getvariables(constraint))
+        @warn "Some variables in factorization constraint $constraint are not present in the context."
+    end
     lhs = map(variable -> resolve(model, context, variable), vfiltered)
     rhs = map(
         entry -> begin

--- a/test/graph_construction_tests.jl
+++ b/test/graph_construction_tests.jl
@@ -752,3 +752,72 @@ end
     @test length(collect(filter(as_node(Bernoulli), model))) === 10
     @test length(collect(filter(as_node(prior), model))) === 1
 end
+
+@testitem "Model that passes a slice to child model" begin
+    using GraphPPL
+    include("testutils.jl")
+
+    @model function mixed_v(y, v)
+        for i in 1:3
+            v[i] ~ Normal(0, 1)
+        end
+        y ~ Normal(v[1], v[2])
+    end
+
+    @model function mixed_m()
+        local m
+        for i in 1:3
+            for j in 1:3
+                m[i, j] ~ Normal(0, 1)
+            end
+        end
+        y ~ mixed_v(v = m[:, 1])
+    end
+
+    model = GraphPPL.create_model(mixed_m()) 
+    context = GraphPPL.getcontext(model)
+
+    @test haskey(context[mixed_v, 1], :v)
+
+end
+
+@testitem "Model that constructs a new array to pass to children" begin
+    using GraphPPL
+    include("testutils.jl")
+
+    @model function mixed_v(y, v)
+        for i in 1:3
+            v[i] ~ Normal(0, 1)
+        end
+        y ~ Normal(v[1], v[2])
+    end
+
+    @model function mixed_m()
+        v1 ~ Normal(0, 1)
+        v2 ~ Normal(0, 1)
+        v3 ~ Normal(0, 1)
+        y ~ mixed_v(v = [v1, v2, v3])
+    end
+
+    model = GraphPPL.create_model(mixed_m()) 
+    context = GraphPPL.getcontext(model)
+
+    @test haskey(context[mixed_v, 1], :v)
+
+    @model function mixed_v(y, v)
+        for i in 1:3
+            v[i] ~ Normal(0, 1)
+        end
+        y ~ Normal(v[1], v[2])
+    end
+
+    @model function mixed_m()
+        v1 ~ Normal(0, 1)
+        v2 ~ Normal(0, 1)
+        v3 ~ Normal(0, 1)
+        v = Matrix([v1 v2; v1 v3])
+        y ~ mixed_v(v = v)
+    end
+
+    @test_throws GraphPPL.NotImplementedError local model = GraphPPL.create_model(mixed_m()) 
+end

--- a/test/plugins/variational_constraints/variational_constraints_engine_tests.jl
+++ b/test/plugins/variational_constraints/variational_constraints_engine_tests.jl
@@ -1330,7 +1330,7 @@ end
             q(mat, y) = q(mat)q(y)
         end
     end
-    @test_throws GraphPPL.UnresolvableFactorizationConstraintError model = create_model(
+    @test_throws GraphPPL.UnresolvableFactorizationConstraintError local model = create_model(
         with_plugins(outer_matrix(), PluginsCollection(VariationalConstraintsPlugin(constraints_7)))
     )
 
@@ -1345,8 +1345,7 @@ end
         v1 ~ Normal(0, 1)
         v2 ~ Normal(0, 1)
         v3 ~ Normal(0, 1)
-        v = GraphPPL.ResizableArray([v1, v2, v3])
-        y ~ mixed_v(v = v)
+        y ~ mixed_v(v = [v1, v2, v3])
     end
 
     constraints_8 = @constraints begin


### PR DESCRIPTION
Relaxed dispatch of `check_variate_compatablility`
Now custom matrices are still a problem when we pass them to child contexts, but at least we throw a `NotImplementedError`