### PR TITLE
Allow `MeanField` constraints

### DIFF
--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -854,11 +854,14 @@ add_to_child_context(child_context::Context, name_in_child::Symbol, object_in_pa
 add_to_child_context(child_context::Context, name_in_child::Symbol, object_in_parent::ResizableArray{NodeLabel, V, N}) where {V, N} =
     set!(child_context.tensor_variables, name_in_child, object_in_parent)
 
-add_to_child_context(child_context::Context, name_in_child::Symbol, object_in_parent::AbstractArray{NodeLabel, 1})  =
+add_to_child_context(child_context::Context, name_in_child::Symbol, object_in_parent::AbstractArray{NodeLabel, 1}) =
     set!(child_context.vector_variables, name_in_child, ResizableArray(object_in_parent))
 
-add_to_child_context(child_context::Context, name_in_child::Symbol, object_in_parent::AbstractArray{NodeLabel, N}) where {N} =
-    throw(NotImplementedError("Currently it's not possible to pass a custom made matrix of random variables to a child context. Maybe you can redefine your model to implicitly create the matrix and pass it like that?"))
+add_to_child_context(child_context::Context, name_in_child::Symbol, object_in_parent::AbstractArray{NodeLabel, N}) where {N} = throw(
+    NotImplementedError(
+        "Currently it's not possible to pass a custom made matrix of random variables to a child context. Maybe you can redefine your model to implicitly create the matrix and pass it like that?"
+    )
+)
 
 add_to_child_context(child_context::Context, name_in_child::Symbol, object_in_parent::ProxyLabel) =
     set!(child_context.proxies, name_in_child, object_in_parent)
@@ -889,7 +892,6 @@ check_variate_compatability(node::AbstractArray{NodeLabel, N}, index::Vararg{Int
 check_variate_compatability(node::AbstractArray{NodeLabel, N}, index::NTuple{N, Int}) where {N} = isassigned(node, index...)
 check_variate_compatability(node::AbstractArray{NodeLabel, N}, index::Vararg{Int, M}) where {N, M} =
     error("Index of length $(length(index)) not possible for $N-dimensional vector of random variables")
-
 
 check_variate_compatability(node::AbstractArray{NodeLabel, N}, index::Nothing) where {N} =
     error("Cannot call vector of random variables on the left-hand-side by an unindexed statement")

--- a/src/plugins/variational_constraints/variational_constraints_engine.jl
+++ b/src/plugins/variational_constraints/variational_constraints_engine.jl
@@ -79,10 +79,12 @@ __factorization_specification_resolve_index(index::CombinedRange, collection::Ab
     __factorization_specification_resolve_index(firstindex(index), collection)::Integer,
     __factorization_specification_resolve_index(lastindex(index), collection)::Integer
 )
-__factorization_specification_resolve_index(index::SplittedRange, collection::AbstractArray{<:NodeLabel}) = SplittedRange(
+__factorization_specification_resolve_index(index::SplittedRange, collection::AbstractArray{<:NodeLabel, N}) where {N} = throw(NotImplementedError("Splitted ranges are not supported for more than 1 dimension, because it is ambiguous."))
+ __factorization_specification_resolve_index(index::SplittedRange, collection::AbstractArray{<:NodeLabel, 1}) = SplittedRange(
     __factorization_specification_resolve_index(firstindex(index), collection)::Integer,
     __factorization_specification_resolve_index(lastindex(index), collection)::Integer
 )
+
 
 # Only these combinations are allowed to be merged
 __factorization_split_merge_range(a::Int, b::Int) = SplittedRange(a, b)
@@ -758,6 +760,26 @@ function resolve(model::Model, context::Context, constraint::FactorizationConstr
         end,
         getconstraint(constraint)
     )
+    return ResolvedFactorizationConstraint(ResolvedConstraintLHS(lhs), rhs)
+end
+
+resolve(model::Model, context::Context, variable::NodeLabel, ::MeanField) = __resolve(model, variable)
+resolve(model::Model, context::Context, variable::AbstractArray{<:NodeLabel, N}, ::MeanField) where {N} = begin
+    firstdata = first(model[variable])
+    ResolvedIndexedVariable(
+    getname(getproperties(firstdata)),
+    SplittedRange(firstindex(variable), lastindex(variable)),
+    getcontext(firstdata)
+)
+end
+
+function resolve(model::Model, context::Context, constraint::FactorizationConstraint{V, <:MeanField} where {V}) 
+    vfiltered = filter(variable -> haskey(context, getname(variable)), getvariables(constraint))
+    if length(vfiltered) != length(getvariables(constraint))
+        @warn "Some variables in factorization constraint $constraint are not present in the context."
+    end
+    lhs = map(variable -> resolve(model, context, variable), vfiltered)
+    rhs = map(variable -> ResolvedFactorizationConstraintEntry((resolve(model, context, context[getname(variable)], MeanField()),)), vfiltered)
     return ResolvedFactorizationConstraint(ResolvedConstraintLHS(lhs), rhs)
 end
 

--- a/src/plugins/variational_constraints/variational_constraints_engine.jl
+++ b/src/plugins/variational_constraints/variational_constraints_engine.jl
@@ -79,12 +79,12 @@ __factorization_specification_resolve_index(index::CombinedRange, collection::Ab
     __factorization_specification_resolve_index(firstindex(index), collection)::Integer,
     __factorization_specification_resolve_index(lastindex(index), collection)::Integer
 )
-__factorization_specification_resolve_index(index::SplittedRange, collection::AbstractArray{<:NodeLabel, N}) where {N} = throw(NotImplementedError("Splitted ranges are not supported for more than 1 dimension, because it is ambiguous."))
- __factorization_specification_resolve_index(index::SplittedRange, collection::AbstractArray{<:NodeLabel, 1}) = SplittedRange(
+__factorization_specification_resolve_index(index::SplittedRange, collection::AbstractArray{<:NodeLabel, N}) where {N} =
+    throw(NotImplementedError("Splitted ranges are not supported for more than 1 dimension, because it is ambiguous."))
+__factorization_specification_resolve_index(index::SplittedRange, collection::AbstractArray{<:NodeLabel, 1}) = SplittedRange(
     __factorization_specification_resolve_index(firstindex(index), collection)::Integer,
     __factorization_specification_resolve_index(lastindex(index), collection)::Integer
 )
-
 
 # Only these combinations are allowed to be merged
 __factorization_split_merge_range(a::Int, b::Int) = SplittedRange(a, b)
@@ -767,19 +767,19 @@ resolve(model::Model, context::Context, variable::NodeLabel, ::MeanField) = __re
 resolve(model::Model, context::Context, variable::AbstractArray{<:NodeLabel, N}, ::MeanField) where {N} = begin
     firstdata = first(model[variable])
     ResolvedIndexedVariable(
-    getname(getproperties(firstdata)),
-    SplittedRange(firstindex(variable), lastindex(variable)),
-    getcontext(firstdata)
-)
+        getname(getproperties(firstdata)), SplittedRange(firstindex(variable), lastindex(variable)), getcontext(firstdata)
+    )
 end
 
-function resolve(model::Model, context::Context, constraint::FactorizationConstraint{V, <:MeanField} where {V}) 
+function resolve(model::Model, context::Context, constraint::FactorizationConstraint{V, <:MeanField} where {V})
     vfiltered = filter(variable -> haskey(context, getname(variable)), getvariables(constraint))
     if length(vfiltered) != length(getvariables(constraint))
         @warn "Some variables in factorization constraint $constraint are not present in the context."
     end
     lhs = map(variable -> resolve(model, context, variable), vfiltered)
-    rhs = map(variable -> ResolvedFactorizationConstraintEntry((resolve(model, context, context[getname(variable)], MeanField()),)), vfiltered)
+    rhs = map(
+        variable -> ResolvedFactorizationConstraintEntry((resolve(model, context, context[getname(variable)], MeanField()),)), vfiltered
+    )
     return ResolvedFactorizationConstraint(ResolvedConstraintLHS(lhs), rhs)
 end
 

--- a/src/plugins/variational_constraints/variational_constraints_engine.jl
+++ b/src/plugins/variational_constraints/variational_constraints_engine.jl
@@ -80,7 +80,7 @@ __factorization_specification_resolve_index(index::CombinedRange, collection::Ab
     __factorization_specification_resolve_index(lastindex(index), collection)::Integer
 )
 __factorization_specification_resolve_index(index::SplittedRange, collection::AbstractArray{<:NodeLabel, N}) where {N} =
-    throw(NotImplementedError("Splitted ranges are not supported for more than 1 dimension, because it is ambiguous."))
+    throw(NotImplementedError("Splitted ranges are not supported for more than 1 dimension."))
 __factorization_specification_resolve_index(index::SplittedRange, collection::AbstractArray{<:NodeLabel, 1}) = SplittedRange(
     __factorization_specification_resolve_index(firstindex(index), collection)::Integer,
     __factorization_specification_resolve_index(lastindex(index), collection)::Integer

--- a/src/resizable_array.jl
+++ b/src/resizable_array.jl
@@ -210,6 +210,7 @@ function firstwithindex(array::ResizableArray{T, V, N}) where {T, V, N}
     end
 end
 
+
 function lastwithindex(array::ResizableArray{T, V, N}) where {T, V, N}
     for index in reverse(CartesianIndices(reverse(size(array)))) #TODO improve performance of this function since it uses splatting
         if isassigned(array, reverse(index.I)...)::Bool

--- a/src/resizable_array.jl
+++ b/src/resizable_array.jl
@@ -210,7 +210,6 @@ function firstwithindex(array::ResizableArray{T, V, N}) where {T, V, N}
     end
 end
 
-
 function lastwithindex(array::ResizableArray{T, V, N}) where {T, V, N}
     for index in reverse(CartesianIndices(reverse(size(array)))) #TODO improve performance of this function since it uses splatting
         if isassigned(array, reverse(index.I)...)::Bool

--- a/test/graph_construction_tests.jl
+++ b/test/graph_construction_tests.jl
@@ -753,7 +753,6 @@ end
     @test length(collect(filter(as_node(prior), model))) === 1
 end
 
-
 @testitem "Model that passes a slice to child model" begin
     using GraphPPL
     include("testutils.jl")
@@ -775,11 +774,10 @@ end
         y ~ mixed_v(v = m[:, 1])
     end
 
-    model = GraphPPL.create_model(mixed_m()) 
+    model = GraphPPL.create_model(mixed_m())
     context = GraphPPL.getcontext(model)
 
     @test haskey(context[mixed_v, 1], :v)
-
 end
 
 @testitem "Model that constructs a new array to pass to children" begin
@@ -800,7 +798,7 @@ end
         y ~ mixed_v(v = [v1, v2, v3])
     end
 
-    model = GraphPPL.create_model(mixed_m()) 
+    model = GraphPPL.create_model(mixed_m())
     context = GraphPPL.getcontext(model)
 
     @test haskey(context[mixed_v, 1], :v)
@@ -820,7 +818,7 @@ end
         y ~ mixed_v(v = v)
     end
 
-    @test_throws GraphPPL.NotImplementedError local model = GraphPPL.create_model(mixed_m()) 
+    @test_throws GraphPPL.NotImplementedError local model = GraphPPL.create_model(mixed_m())
 end
 
 @testitem "Model creation should throw if a `~` using with a constant on RHS" begin
@@ -837,8 +835,9 @@ end
         end
     end
 
-    @test_throws "`Matrix` cannot be used as a factor node. Both the arguments and the node are not stochastic." create_model(broken_beta_bernoulli()) do model, context 
+    @test_throws "`Matrix` cannot be used as a factor node. Both the arguments and the node are not stochastic." create_model(
+        broken_beta_bernoulli()
+    ) do model, context
         return (; y = getorcreate!(model, context, NodeCreationOptions(kind = :data), :y, LazyIndex(rand(10))))
     end
 end
-

--- a/test/graph_engine_tests.jl
+++ b/test/graph_engine_tests.jl
@@ -105,7 +105,7 @@ end
     end
 end
 
-@testitem "NodeDataExtraKey" begin 
+@testitem "NodeDataExtraKey" begin
     import GraphPPL: NodeDataExtraKey, getkey
 
     @test NodeDataExtraKey{:a, Int}() isa NodeDataExtraKey

--- a/test/plugins/variational_constraints/variational_constraints_engine_tests.jl
+++ b/test/plugins/variational_constraints/variational_constraints_engine_tests.jl
@@ -1407,12 +1407,10 @@ end
     )
 
     constraints_11 = @constraints begin
-        q(x, z, y) = q(z)(q(x[begin + 1])..q(x[end]))(q(y[begin + 1])..q(y[end]))
+        q(x, z, y) = q(z)(q(x[begin + 1]) .. q(x[end]))(q(y[begin + 1]) .. q(y[end]))
     end
 
-    model = create_model(
-        with_plugins(vector_model(), PluginsCollection(VariationalConstraintsPlugin(constraints_11)))
-    )
+    model = create_model(with_plugins(vector_model(), PluginsCollection(VariationalConstraintsPlugin(constraints_11))))
 
     ctx = getcontext(model)
     for node in filter(as_node(Normal), model)
@@ -1422,9 +1420,9 @@ end
             @test getextra(model[node], :factorization_constraint_indices) == ([1], [2], [3])
         end
     end
-    
+
     constraints_12 = @constraints begin
-        q(mat) = q(mat[begin])..q(mat[end])
+        q(mat) = q(mat[begin]) .. q(mat[end])
     end
     @test_throws NotImplementedError local model = create_model(
         with_plugins(outer_matrix(), PluginsCollection(VariationalConstraintsPlugin(constraints_12)))

--- a/test/plugins/variational_constraints/variational_constraints_macro_tests.jl
+++ b/test/plugins/variational_constraints/variational_constraints_macro_tests.jl
@@ -654,16 +654,36 @@ end
 
     for constraints in [constraints1, constraints2, constraints3]
         c = first(GraphPPL.factorization_constraints(constraints))
-        @test GraphPPL.getvariables(c) == (GraphPPL.IndexedVariable(:x, nothing), GraphPPL.IndexedVariable(:y, nothing), GraphPPL.IndexedVariable(:z, nothing))
-        @test GraphPPL.getconstraint(c) == GraphPPL.FactorizationConstraintEntry((GraphPPL.IndexedVariable(:x, nothing),)) * GraphPPL.FactorizationConstraintEntry((GraphPPL.IndexedVariable(:y, nothing),)) * GraphPPL.FactorizationConstraintEntry((GraphPPL.IndexedVariable(:z, nothing),))
+        @test GraphPPL.getvariables(c) ==
+            (GraphPPL.IndexedVariable(:x, nothing), GraphPPL.IndexedVariable(:y, nothing), GraphPPL.IndexedVariable(:z, nothing))
+        @test GraphPPL.getconstraint(c) ==
+            GraphPPL.FactorizationConstraintEntry((GraphPPL.IndexedVariable(:x, nothing),)) *
+              GraphPPL.FactorizationConstraintEntry((GraphPPL.IndexedVariable(:y, nothing),)) *
+              GraphPPL.FactorizationConstraintEntry((GraphPPL.IndexedVariable(:z, nothing),))
     end
-
 
     constraints = @constraints begin
         q(z, s, m, p) = q(z)q(s)(q(m[begin]) .. q(m[end]))(q(p[begin]) .. q(p[end]))
     end
 
     con = first(GraphPPL.factorization_constraints(constraints))
-    @test GraphPPL.getvariables(con) == (GraphPPL.IndexedVariable(:z, nothing), GraphPPL.IndexedVariable(:s, nothing), GraphPPL.IndexedVariable(:m, nothing), GraphPPL.IndexedVariable(:p, nothing))
-    @test GraphPPL.getconstraint(con) == GraphPPL.FactorizationConstraintEntry((GraphPPL.IndexedVariable(:z, nothing),)) * GraphPPL.FactorizationConstraintEntry((GraphPPL.IndexedVariable(:s, nothing),)) * GraphPPL.FactorizationConstraintEntry((GraphPPL.IndexedVariable(:m, GraphPPL.SplittedRange(GraphPPL.FunctionalIndex{:begin}(firstindex), GraphPPL.FunctionalIndex{:end}(lastindex))),)) * GraphPPL.FactorizationConstraintEntry((GraphPPL.IndexedVariable(:p, GraphPPL.SplittedRange(GraphPPL.FunctionalIndex{:begin}(firstindex), GraphPPL.FunctionalIndex{:end}(lastindex))),))
-end        
+    @test GraphPPL.getvariables(con) == (
+        GraphPPL.IndexedVariable(:z, nothing),
+        GraphPPL.IndexedVariable(:s, nothing),
+        GraphPPL.IndexedVariable(:m, nothing),
+        GraphPPL.IndexedVariable(:p, nothing)
+    )
+    @test GraphPPL.getconstraint(con) ==
+        GraphPPL.FactorizationConstraintEntry((GraphPPL.IndexedVariable(:z, nothing),)) *
+          GraphPPL.FactorizationConstraintEntry((GraphPPL.IndexedVariable(:s, nothing),)) *
+          GraphPPL.FactorizationConstraintEntry((
+              GraphPPL.IndexedVariable(
+                  :m, GraphPPL.SplittedRange(GraphPPL.FunctionalIndex{:begin}(firstindex), GraphPPL.FunctionalIndex{:end}(lastindex))
+              ),
+          )) *
+          GraphPPL.FactorizationConstraintEntry((
+              GraphPPL.IndexedVariable(
+                  :p, GraphPPL.SplittedRange(GraphPPL.FunctionalIndex{:begin}(firstindex), GraphPPL.FunctionalIndex{:end}(lastindex))
+              ),
+          ))
+end

--- a/test/plugins/variational_constraints/variational_constraints_tests.jl
+++ b/test/plugins/variational_constraints/variational_constraints_tests.jl
@@ -248,6 +248,10 @@ end
             q(t, x, y) = q(t)q(y)q(x)
         end
 
+        structured_factorization_1_10 = @constraints begin
+            q(t, x, y) = MeanField()
+        end
+
         # These should be equivalent
         constraints = [
             structured_factorization_1_1,
@@ -258,7 +262,8 @@ end
             structured_factorization_1_6,
             structured_factorization_1_7,
             structured_factorization_1_8,
-            structured_factorization_1_9
+            structured_factorization_1_9,
+            structured_factorization_1_10
         ]
 
         for constraint in constraints
@@ -541,8 +546,16 @@ end
             end
         end
     end
+    constraints6 = @constraints begin
+        q(x) = MeanField()
+        for q in nested1
+            for q in nested2
+                q(u, θ) = q(u)q(θ)
+            end
+        end
+    end
 
-    @testset for n in 1:5, constraints in (constraints1, constraints2, constraints3, constraints4, constraints5)
+    @testset for n in 1:5, constraints in (constraints1, constraints2, constraints3, constraints4, constraints5, constraints6)
         model = create_model(
             with_plugins(random_walk(a = 1, b = 2), PluginsCollection(VariationalConstraintsPlugin(constraints)))
         ) do model, context


### PR DESCRIPTION
This PR allows the following syntax:
```julia
@constraints begin
    q(x, y) = MeanFieldI()
    q(z) = MeanField()
end
```
While building this, I also found a bug. When `mat` is a matrix valued RV and the user specified:
```julia
@constraints begin
    q(mat) = q(mat[begin])..q(mat[end])
end
```
and obscure error was thrown. Because of the way we encode ranges in the current implementation we actually don't allow multidimensional splitted ranges so a helpful error message will now be thrown.