### PR TITLE
Fold data/const variables automatically with anonymous deterministic fform

### DIFF
--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -1203,7 +1203,7 @@ function materialize_anonymous_variable!(::Deterministic, model::Model, context:
     link_const, link_const_or_data = reduce(Iterators.map(getproperties, linked); init = (true, true)) do accum, props
         check_is_all_constant, check_is_all_constant_or_data = accum
         check_is_all_constant = check_is_all_constant && is_constant(props)
-        check_is_all_constant_or_data = check_is_all_constant_or_data && (check_is_all_constant || is_data(props))
+        check_is_all_constant_or_data = check_is_all_constant_or_data && (is_constant(props) || is_data(props))
         return (check_is_all_constant, check_is_all_constant_or_data)
     end
 

--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -1251,7 +1251,7 @@ function materialize_anonymous_variable!(::Deterministic, model::Model, context:
         (
             false,
             add_variable_node!(
-                model, context, NodeCreationOptions(kind = :data, value = fform, link = linked), VariableNameAnonymous, nothing
+                model, context, NodeCreationOptions(kind = :data, value = (fform, args), link = linked), VariableNameAnonymous, nothing
             )
         )
     else

--- a/test/graph_construction_tests.jl
+++ b/test/graph_construction_tests.jl
@@ -1139,6 +1139,17 @@ end
             @test length(collect(filter(as_node(f), model))) === 0
             @test length(collect(filter(as_node(Normal), model))) === 1
             @test length(filter(label -> is_data(getproperties(model[label])), collect(variable_nodes(model)))) === 2
+
+            # `a` and `b` are either const or datavars
+            model = create_model(fold_datavars_1(f = f)) do model, ctx
+                a = getorcreate!(model, ctx, NodeCreationOptions(kind = :data, factorized = true), :a, nothing)
+                b = getorcreate!(model, ctx, NodeCreationOptions(kind = :constant, value = 1.0), :b, nothing)
+                return (a = a, b = b)
+            end
+
+            @test length(collect(filter(as_node(f), model))) === 0
+            @test length(collect(filter(as_node(Normal), model))) === 1
+            @test length(filter(label -> is_data(getproperties(model[label])), collect(variable_nodes(model)))) === 2
         end
 
         @testset "fold_datavars_2 with just constants" begin

--- a/test/graph_construction_tests.jl
+++ b/test/graph_construction_tests.jl
@@ -1240,7 +1240,10 @@ end
 
             datavars = filter(label -> is_data(getproperties(model[label])), collect(variable_nodes(model)))
             @test length(datavars) === 3
-            @test count(datavars -> value(getproperties(model[datavars])) === f, datavars) === 1
+            @test count(
+                datavars -> !isnothing(value(getproperties(model[datavars]))) && first(value(getproperties(model[datavars]))) === f,
+                datavars
+            ) === 1
 
             # `a` and `b` are either const or datavars
             model = create_model(fold_datavars_1(f = f)) do model, ctx
@@ -1277,6 +1280,16 @@ end
             @test length(collect(filter(as_node(Normal), model))) === 1
             @test length(collect(filter(as_variable(VariableNameAnonymous), model))) === 1
             @test length(filter(label -> is_data(getproperties(model[label])), collect(variable_nodes(model)))) === 2
+
+            foreach(collect(filter(as_variable(VariableNameAnonymous), model))) do label
+                nodedata = model[label]
+                nodeproperties = getproperties(nodedata)
+                fform, args = value(nodeproperties)
+
+                @test fform === f
+                @test length(args) === 2
+                @test args[2] === 1.0
+            end
         end
 
         @testset "fold_datavars_2 with just constants" begin

--- a/test/graph_engine_tests.jl
+++ b/test/graph_engine_tests.jl
@@ -320,7 +320,7 @@ end
 @testitem "variable_nodes with anonymous variables" begin
     # The idea here is that the `variable_nodes` must return ALL anonymous variables as well
     using Distributions
-    import GraphPPL: create_model, variable_nodes, getname
+    import GraphPPL: create_model, variable_nodes, getname, is_anonymous, getproperties
 
     include("testutils.jl")
 
@@ -343,13 +343,13 @@ end
     @testset let submodel = simple_submodel_with_2_anonymous_for_variable_nodes
         model = create_model(simple_model_for_variable_nodes(submodel = submodel))
         @test length(collect(variable_nodes(model))) === 11
-        @test length(collect(filter(v -> getname(v) === :anonymous, collect(variable_nodes(model))))) === 2
+        @test length(collect(filter(v -> is_anonymous(getproperties(model[v])), collect(variable_nodes(model))))) === 2
     end
 
     @testset let submodel = simple_submodel_with_3_anonymous_for_variable_nodes
         model = create_model(simple_model_for_variable_nodes(submodel = submodel))
         @test length(collect(variable_nodes(model))) === 13 # +1 for new anonymous +1 for new constant
-        @test length(collect(filter(v -> getname(v) === :anonymous, collect(variable_nodes(model))))) === 3
+        @test length(collect(filter(v -> is_anonymous(getproperties(model[v])), collect(variable_nodes(model))))) === 3
     end
 end
 


### PR DESCRIPTION
This PR re-implements a previously available feature within GraphPPL where data/const variables were creating data variable when used with anonymous deterministic fform