### PR TITLE
Allow return statement from the model/submodels

### DIFF
--- a/src/model_macro.jl
+++ b/src/model_macro.jl
@@ -714,7 +714,8 @@ function get_make_node_function(ms_body, ms_args, ms_name)
             __context__ = GraphPPL.Context(__parent_context__, $ms_name)
             GraphPPL.copy_markov_blanket_to_child_context(__context__, __interfaces__)
             GraphPPL.add_composite_factor_node!(__model__, __parent_context__, __context__, $ms_name)
-            GraphPPL.add_terminated_submodel!(__model__, __context__, __options__, $ms_name, __interfaces__, __n_interfaces__)
+            __returnval__ = GraphPPL.add_terminated_submodel!(__model__, __context__, __options__, $ms_name, __interfaces__, __n_interfaces__)
+            GraphPPL.returnval!(__context__, __returnval__)
             return __context__, GraphPPL.unroll(__lhs_interface__)
         end
 

--- a/test/graph_engine_tests.jl
+++ b/test/graph_engine_tests.jl
@@ -952,6 +952,13 @@ end
     @test !isempty(output)
     @test contains(output, "identity") # fform
 
+    # By default `returnval` is not defined
+    @test_throws UndefRefError GraphPPL.returnval(ctx1)
+    for i in 1:10
+        GraphPPL.returnval!(ctx1, (i, "$i"))
+        @test GraphPPL.returnval(ctx1) == (i, "$i")
+    end
+
     function test end
 
     ctx2 = Context(0, test, "test", nothing)
@@ -972,6 +979,8 @@ end
 
     ctx6 = Context(ctx3, secondlayer)
     @test typeof(ctx6) == Context && ctx6.prefix == "test_layer_secondlayer" && length(ctx6.individual_variables) == 0 && ctx6.depth == 2
+
+
 end
 
 @testitem "haskey(::Context)" begin


### PR DESCRIPTION
This PR re-implements a feature from old `GraphPPL` where models allowed to "return" some values from inside. Might be useful for debugging by end-users.