### PR TITLE
Add `with_backend` and allow parameterized backends

### DIFF
--- a/src/GraphPPL.jl
+++ b/src/GraphPPL.jl
@@ -50,7 +50,7 @@ the `@model` macro to the current scope.
 
 """
 macro model(model_specification)
-    return esc(GraphPPL.model_macro_interior(DefaultBackend(), model_specification))
+    return esc(GraphPPL.model_macro_interior(DefaultBackend, model_specification))
 end
 
 end # module

--- a/src/backends/default.jl
+++ b/src/backends/default.jl
@@ -42,3 +42,11 @@ GraphPPL.interface_aliases(::DefaultBackend, _) = GraphPPL.StaticInterfaceAliase
 default_parametrization(::DefaultBackend, ::Atomic, fform::F, rhs::Tuple) where {F} = (in = rhs,)
 default_parametrization(::DefaultBackend, ::Composite, fform::F, rhs) where {F} =
     error("Composite nodes always have to be initialized with named arguments")
+
+"""
+    instantiate(::Type{Backend})
+
+instantiates a backend object of the specified type. Should be implemented for all backends.
+"""
+instantiate(any) = error("Backend of type $any does not implement `instantiate`")
+instantiate(::Type{DefaultBackend}) = DefaultBackend()

--- a/src/backends/default.jl
+++ b/src/backends/default.jl
@@ -43,10 +43,5 @@ default_parametrization(::DefaultBackend, ::Atomic, fform::F, rhs::Tuple) where 
 default_parametrization(::DefaultBackend, ::Composite, fform::F, rhs) where {F} =
     error("Composite nodes always have to be initialized with named arguments")
 
-"""
-    instantiate(::Type{Backend})
-
-instantiates a backend object of the specified type. Should be implemented for all backends.
-"""
-instantiate(any) = error("Backend of type $any does not implement `instantiate`")
-instantiate(::Type{DefaultBackend}) = DefaultBackend()
+# The default backend does not really have any special hyperparameters
+GraphPPL.instantiate(::Type{DefaultBackend}) = DefaultBackend()

--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -1421,7 +1421,6 @@ function add_edge!(
 )
     label = EdgeLabel(interface_name, index)
     neighbor_node_label = unroll(variable_node_id)
-    # TODO: (bvdmitri) perhaps we should use a different data structure for neighbors, tuples extension might be slow
     addneighbor!(factor_node_propeties, neighbor_node_label, label, model[neighbor_node_label])
     model.graph[unroll(variable_node_id), factor_node_id] = label
 end
@@ -1534,6 +1533,14 @@ function default_parametrization end
 default_parametrization(backend, nodetype, fform, rhs) =
     error("The backend $backend must implement a method for `default_parametrization` for `$(fform)` (`$(nodetype)`) and `$(rhs)`.")
 default_parametrization(model::Model, nodetype, fform::F, rhs) where {F} = default_parametrization(getbackend(model), nodetype, fform, rhs)
+
+
+"""
+    instantiate(::Type{Backend})
+
+Instantiates a default backend object of the specified type. Should be implemented for all backends.
+"""
+instantiate(backendtype) = error("The backend of type $backendtype must implement a method for `instantiate`.")
 
 # maybe change name
 

--- a/src/model_generator.jl
+++ b/src/model_generator.jl
@@ -5,20 +5,26 @@
 The `ModelGenerator` structure is used to lazily create 
 the model with the given `model` and `kwargs` and `plugins`.
 """
-struct ModelGenerator{G, K, P}
+struct ModelGenerator{G, K, P, B}
     model::G
     kwargs::K
     plugins::P
+    backend::B
 end
 
-ModelGenerator(model::G, kwargs::K) where {G, K} = ModelGenerator(model, kwargs, PluginsCollection())
+ModelGenerator(model::G, kwargs::K) where {G, K} = ModelGenerator(model, kwargs, PluginsCollection(), default_backend(model))
 
 getmodel(generator::ModelGenerator) = generator.model
 getkwargs(generator::ModelGenerator) = generator.kwargs
 getplugins(generator::ModelGenerator) = generator.plugins
+getbackend(generator::ModelGenerator) = generator.backend
 
 function with_plugins(generator::ModelGenerator, plugins::PluginsCollection)
     return ModelGenerator(generator.model, generator.kwargs, generator.plugins + plugins)
+end
+
+function with_backend(generator::ModelGenerator, backend)
+    return ModelGenerator(generator.model, generator.kwargs, generator.plugins, backend)
 end
 
 function create_model(generator::ModelGenerator)
@@ -28,7 +34,7 @@ function create_model(generator::ModelGenerator)
 end
 
 function create_model(callback, generator::ModelGenerator)
-    model = Model(getmodel(generator), getplugins(generator))
+    model = Model(getmodel(generator), getplugins(generator), getbackend(generator))
     context = getcontext(model)
 
     extrakwargs = callback(model, context)

--- a/src/model_generator.jl
+++ b/src/model_generator.jl
@@ -20,7 +20,7 @@ getplugins(generator::ModelGenerator) = generator.plugins
 getbackend(generator::ModelGenerator) = generator.backend
 
 function with_plugins(generator::ModelGenerator, plugins::PluginsCollection)
-    return ModelGenerator(generator.model, generator.kwargs, generator.plugins + plugins)
+    return ModelGenerator(generator.model, generator.kwargs, generator.plugins + plugins, generator.backend)
 end
 
 function with_backend(generator::ModelGenerator, backend)

--- a/src/model_macro.jl
+++ b/src/model_macro.jl
@@ -563,7 +563,9 @@ __combine_axes() = Base.OneTo(1)
 __combine_axes(any...) = Base.Broadcast.combine_axes(any...)
 
 __check_vectorized_input(any) = last.(any)
-__check_vectorized_input(::Tuple{T, GraphPPL.NodeLabel}) where {T} = error("Cannot broadcast scalar inputs over an unspecified or one-dimensional return array. Did you accidentally make a statement like this: `x ~ Bernoulli(Beta.(1, 1))` without initializing `x`?")
+__check_vectorized_input(::Tuple{T, GraphPPL.NodeLabel}) where {T} = error(
+    "Cannot broadcast scalar inputs over an unspecified or one-dimensional return array. Did you accidentally make a statement like this: `x ~ Bernoulli(Beta.(1, 1))` without initializing `x`?"
+)
 
 """
     convert_tilde_expression(e::Expr)
@@ -659,10 +661,9 @@ Returns a quote block containing boilerplate functions for a model macro.
 # Returns
 - `quote`: A quote block containing the boilerplate functions for the model macro.
 """
-function get_boilerplate_functions(backend, ms_name, ms_args, num_interfaces)
+function get_boilerplate_functions(backend_type, ms_name, ms_args, num_interfaces)
     error_msg = "$(ms_name) Composite node cannot be invoked with"
     ms_args = map(arg -> preprocess_interface_expression(arg), ms_args)
-    backend_type = typeof(backend)
     return quote
         function $ms_name end
         GraphPPL.interfaces(::$backend_type, ::typeof($ms_name), val) = error($error_msg * " $val keywords")
@@ -671,7 +672,7 @@ function get_boilerplate_functions(backend, ms_name, ms_args, num_interfaces)
         GraphPPL.NodeType(::$backend_type, ::typeof($ms_name)) = GraphPPL.Composite()
         GraphPPL.NodeBehaviour(::$backend_type, ::typeof($ms_name)) = GraphPPL.Stochastic()
         GraphPPL.aliases(::$backend_type, f::typeof($ms_name)) = (f,)
-        GraphPPL.default_backend(::typeof($ms_name)) = $backend
+        GraphPPL.default_backend(::typeof($ms_name)) = $(GraphPPL.instantiate(backend_type))
     end
 end
 
@@ -717,7 +718,9 @@ function get_make_node_function(ms_body, ms_args, ms_name)
             __context__ = GraphPPL.Context(__parent_context__, $ms_name)
             GraphPPL.copy_markov_blanket_to_child_context(__context__, __interfaces__)
             GraphPPL.add_composite_factor_node!(__model__, __parent_context__, __context__, $ms_name)
-            __returnval__ = GraphPPL.add_terminated_submodel!(__model__, __context__, __options__, $ms_name, __interfaces__, __n_interfaces__)
+            __returnval__ = GraphPPL.add_terminated_submodel!(
+                __model__, __context__, __options__, $ms_name, __interfaces__, __n_interfaces__
+            )
             GraphPPL.returnval!(__context__, __returnval__)
             return __context__, GraphPPL.unroll(__lhs_interface__)
         end
@@ -760,7 +763,7 @@ The functions are being applied to the model in the `model_macro_interior` macro
 """
 function model_macro_interior_pipelines end
 
-function model_macro_interior(backend, model_specification)
+function model_macro_interior(backend_type, model_specification)
     @capture(model_specification, (function ms_name_(ms_args__; ms_kwargs__)
         ms_body_
     end) | (function ms_name_(ms_args__)
@@ -772,8 +775,8 @@ function model_macro_interior(backend, model_specification)
         @warn("Model specification language does not support keyword arguments. Ignoring $(length(ms_kwargs)) keyword arguments.")
     end
 
-    boilerplate_functions = GraphPPL.get_boilerplate_functions(backend, ms_name, ms_args, num_interfaces)
-    pipeline_collection = GraphPPL.model_macro_interior_pipelines(backend)
+    boilerplate_functions = GraphPPL.get_boilerplate_functions(backend_type, ms_name, ms_args, num_interfaces)
+    pipeline_collection = GraphPPL.model_macro_interior_pipelines(instantiate(backend_type))
     ms_body = apply_pipeline_collection(ms_body, pipeline_collection)
 
     make_node_function = get_make_node_function(ms_body, ms_args, ms_name)

--- a/test/backends/default_tests.jl
+++ b/test/backends/default_tests.jl
@@ -1,0 +1,53 @@
+@testitem "Instantiation" begin
+    import GraphPPL: DefaultBackend, instantiate
+
+    @test instantiate(DefaultBackend) == DefaultBackend()
+end
+
+@testitem "NodeBehaviour" begin
+    using Distributions
+    import GraphPPL: DefaultBackend, NodeBehaviour, Stochastic, Deterministic
+
+    include("../testutils.jl")
+
+    using .TestUtils.ModelZoo
+
+    # The `DefaultBackend` defines `Stochastic` behaviour for objects from the `Distributions` module
+    @test NodeBehaviour(DefaultBackend(), Normal) == Stochastic()
+    @test NodeBehaviour(DefaultBackend(), Gamma) == Stochastic()
+
+    # By default all Julia functions are detereministic
+    @test NodeBehaviour(DefaultBackend(), sum) == Deterministic()
+    @test NodeBehaviour(DefaultBackend(), prod) == Deterministic()
+    @test NodeBehaviour(DefaultBackend(), (x) -> x + 1) == Deterministic()
+
+    # Raw Julia types are also deterministic
+    @test NodeBehaviour(DefaultBackend(), Matrix) == Deterministic()
+    @test NodeBehaviour(DefaultBackend(), Vector) == Deterministic()
+
+    # Submodels are defined to be stochastic
+    for model in ModelsInTheZooWithoutArguments
+        @test NodeBehaviour(DefaultBackend(), model) == Stochastic()
+    end
+end
+
+@testitem "NodeType" begin
+    using Distributions
+    import GraphPPL: DefaultBackend, NodeType, Atomic, Composite
+
+    include("../testutils.jl")
+    
+    using .TestUtils.ModelZoo
+
+    # The `DefaultBackend` defines `Atomic` behaviour for objects from the `Distributions` module
+    # but also for functions and types
+    @test NodeType(DefaultBackend(), Normal) == Atomic()
+    @test NodeType(DefaultBackend(), Gamma) == Atomic()
+    @test NodeType(DefaultBackend(), Matrix) == Atomic()
+    @test NodeType(DefaultBackend(), Vector) == Atomic()
+
+    # Composite nodes are defined explicitly in the `@model` macro
+    for model in ModelsInTheZooWithoutArguments
+        @test NodeType(DefaultBackend(), model) == Composite()
+    end
+end

--- a/test/backends/default_tests.jl
+++ b/test/backends/default_tests.jl
@@ -25,19 +25,19 @@ end
     @test NodeBehaviour(DefaultBackend(), Matrix) == Deterministic()
     @test NodeBehaviour(DefaultBackend(), Vector) == Deterministic()
 
-    # Submodels are defined to be stochastic
-    for model in ModelsInTheZooWithoutArguments
-        @test NodeBehaviour(DefaultBackend(), model) == Stochastic()
+    import GraphPPL: @model
+
+    @model function submodel(y, x, z)
+        y ~ Normal(x, z)
     end
+
+    # Composite nodes are defined explicitly in the `@model` macro
+    @test NodeBehaviour(DefaultBackend(), submodel) == Stochastic()
 end
 
 @testitem "NodeType" begin
     using Distributions
     import GraphPPL: DefaultBackend, NodeType, Atomic, Composite
-
-    include("../testutils.jl")
-    
-    using .TestUtils.ModelZoo
 
     # The `DefaultBackend` defines `Atomic` behaviour for objects from the `Distributions` module
     # but also for functions and types
@@ -46,8 +46,12 @@ end
     @test NodeType(DefaultBackend(), Matrix) == Atomic()
     @test NodeType(DefaultBackend(), Vector) == Atomic()
 
-    # Composite nodes are defined explicitly in the `@model` macro
-    for model in ModelsInTheZooWithoutArguments
-        @test NodeType(DefaultBackend(), model) == Composite()
+    import GraphPPL: @model
+
+    @model function submodel(y, x, z)
+        y ~ Normal(x, z)
     end
+
+    # Composite nodes are defined explicitly in the `@model` macro
+    @test NodeType(DefaultBackend(), submodel) == Composite()
 end

--- a/test/model_generator_tests.jl
+++ b/test/model_generator_tests.jl
@@ -207,3 +207,28 @@ end
             PluginsCollection(ArbitraryPluginForModelGeneratorTests1(), ArbitraryPluginForModelGeneratorTests2())
     end
 end
+
+@testitem "with_backend" begin
+    import GraphPPL: ModelGenerator, DefaultBackend, with_backend, getbackend, create_model
+
+    include("testutils.jl")
+
+    # `GraphPPL.@model` uses the `DefaultBackend`, while `@model` from `testutils.jl` uses the `TestBackend`
+    GraphPPL.@model function simple_model(a)
+        y ~ Normal(a, 1)
+    end
+
+    generator = ModelGenerator(simple_model, (a = 1,))
+    @test getbackend(generator) === DefaultBackend()
+
+    model = create_model(generator) 
+    @test model isa GraphPPL.Model
+    @test getbackend(model) === DefaultBackend()
+
+    generator_with_a_different_backend = @inferred(with_backend(generator, TestUtils.TestGraphPPLBackend()))
+    @test getbackend(generator_with_a_different_backend) === TestUtils.TestGraphPPLBackend()
+
+    model_with_a_different_backend = create_model(generator_with_a_different_backend)
+    @test model_with_a_different_backend isa GraphPPL.Model
+    @test getbackend(model_with_a_different_backend) === TestUtils.TestGraphPPLBackend()
+end

--- a/test/model_generator_tests.jl
+++ b/test/model_generator_tests.jl
@@ -189,7 +189,9 @@ end
     end
 
     @testset begin
-        generator = ModelGenerator(identity, (a = 1,), PluginsCollection(ArbitraryPluginForModelGeneratorTests1()))
+        generator = ModelGenerator(
+            identity, (a = 1,), PluginsCollection(ArbitraryPluginForModelGeneratorTests1()), GraphPPL.DefaultBackend()
+        )
 
         @test !isempty(getplugins(generator))
         @test getplugins(generator) === PluginsCollection(ArbitraryPluginForModelGeneratorTests1())

--- a/test/model_generator_tests.jl
+++ b/test/model_generator_tests.jl
@@ -165,7 +165,7 @@ end
 end
 
 @testitem "with_plugins" begin
-    import GraphPPL: ModelGenerator, PluginsCollection, AbstractPluginTraitType, getplugins, with_plugins
+    import GraphPPL: ModelGenerator, PluginsCollection, AbstractPluginTraitType, getplugins, with_plugins, @model
 
     struct ArbitraryPluginForModelGeneratorTestsType1 <: AbstractPluginTraitType end
     struct ArbitraryPluginForModelGeneratorTestsType2 <: AbstractPluginTraitType end
@@ -176,8 +176,12 @@ end
     GraphPPL.plugin_type(::ArbitraryPluginForModelGeneratorTests1) = ArbitraryPluginForModelGeneratorTestsType1()
     GraphPPL.plugin_type(::ArbitraryPluginForModelGeneratorTests2) = ArbitraryPluginForModelGeneratorTestsType2()
 
+    @model function simple_model(a)
+        y ~ Normal(a, 1)
+    end
+
     @testset begin
-        generator = ModelGenerator(identity, (a = 1,))
+        generator = ModelGenerator(simple_model, (a = 1,))
 
         @test isempty(getplugins(generator))
         @test getplugins(generator) === PluginsCollection()
@@ -190,7 +194,7 @@ end
 
     @testset begin
         generator = ModelGenerator(
-            identity, (a = 1,), PluginsCollection(ArbitraryPluginForModelGeneratorTests1()), GraphPPL.DefaultBackend()
+            simple_model, (a = 1,), PluginsCollection(ArbitraryPluginForModelGeneratorTests1()), GraphPPL.DefaultBackend()
         )
 
         @test !isempty(getplugins(generator))

--- a/test/model_macro_tests.jl
+++ b/test/model_macro_tests.jl
@@ -1194,11 +1194,13 @@ end
         x = if !@isdefined(x)
             GraphPPL.getorcreate!(__model__, __context__, :x, (nothing,)...)
         else
-            (if GraphPPL.check_variate_compatability(x, (nothing,)...)
+            (
+                if GraphPPL.check_variate_compatability(x, (nothing,)...)
                     x
                 else
                     GraphPPL.getorcreate!(__model__, __context__, :x, (nothing,)...)
-                end)
+                end
+            )
         end
         x ~ Normal(0, 1) where {created_by = (x ~ Normal(0, 1))}
     end
@@ -1274,11 +1276,13 @@ end
         x = if !@isdefined(x)
             GraphPPL.getorcreate!(__model__, __context__, :x, (nothing,)...)
         else
-            (if GraphPPL.check_variate_compatability(x, (nothing,)...)
+            (
+                if GraphPPL.check_variate_compatability(x, (nothing,)...)
                     x
                 else
                     GraphPPL.getorcreate!(__model__, __context__, :x, (nothing,)...)
-                end)
+                end
+            )
         end
         x ~ Normal(
             begin
@@ -1308,11 +1312,13 @@ end
         y = if !@isdefined(y)
             GraphPPL.getorcreate!(__model__, __context__, :y, (nothing,)...)
         else
-            (if GraphPPL.check_variate_compatability(y, (nothing,)...)
+            (
+                if GraphPPL.check_variate_compatability(y, (nothing,)...)
                     y
                 else
                     GraphPPL.getorcreate!(__model__, __context__, :y, (nothing,)...)
-                end)
+                end
+            )
         end
         y ~ x where {created_by = (y := x), is_deterministic = true}
     end
@@ -1326,11 +1332,13 @@ end
         x = if !@isdefined(x)
             GraphPPL.getorcreate!(__model__, __context__, :x, (nothing,)...)
         else
-            (if GraphPPL.check_variate_compatability(x, (nothing,)...)
+            (
+                if GraphPPL.check_variate_compatability(x, (nothing,)...)
                     x
                 else
                     GraphPPL.getorcreate!(__model__, __context__, :x, (nothing,)...)
-                end)
+                end
+            )
         end
         x ~ Normal(0, 1) where {created_by = (x ~ Normal(0, 1) where {q = q(x)q(y)}), q = q(x)q(y)}
     end
@@ -2004,7 +2012,7 @@ end
         end
     end
 
-    eval(model_macro_interior(TestUtils.TestGraphPPLBackend(), model_spec))
+    eval(model_macro_interior(TestUtils.TestGraphPPLBackend, model_spec))
 
     @test default_backend(hello) === TestUtils.TestGraphPPLBackend()
 end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -43,6 +43,7 @@ GraphPPL.factor_alias(::TestGraphPPLBackend, f, interfaces) = GraphPPL.factor_al
 GraphPPL.interface_aliases(::TestGraphPPLBackend, f) = GraphPPL.interface_aliases(GraphPPL.DefaultBackend(), f)
 GraphPPL.default_parametrization(::TestGraphPPLBackend, nodetype, f, rhs) =
     GraphPPL.default_parametrization(GraphPPL.DefaultBackend(), nodetype, f, rhs)
+GraphPPL.instantiate(::Type{TestGraphPPLBackend}) = TestGraphPPLBackend()
 
 # Check that we can alias the `+` into `sum` and `*` into `prod`
 GraphPPL.factor_alias(::TestGraphPPLBackend, ::typeof(+), interfaces) = sum
@@ -52,7 +53,7 @@ export @model
 
 # This is a special `@model` macro that should be used in tests
 macro model(model_specification)
-    return esc(GraphPPL.model_macro_interior(TestGraphPPLBackend(), model_specification))
+    return esc(GraphPPL.model_macro_interior(TestGraphPPLBackend, model_specification))
 end
 
 export create_test_model


### PR DESCRIPTION
Requires some changes downstream, since we have to implement `instantiate` for custom backends and change the model macro