### PR TITLE
Set minimum required version of Julia to 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,7 +39,7 @@ Static = "0.8"
 StaticArrays = "1.6"
 TupleTools = "1.4"
 Unrolled = "0.1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"


### PR DESCRIPTION
This PR changes the `[compat]` entry to support Julia 1.10+. Closes #230 