### PR TITLE
Constants increase model counter twice

### DIFF
--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -1461,8 +1461,6 @@ function add_variable_node!(model::Model, context::Context, name::Symbol, index)
 end
 
 function add_variable_node!(model::Model, context::Context, options::NodeCreationOptions, name::Symbol, index)
-
-    # In theory plugins are able to overwrite this
     label = __add_variable_node!(model, context, options, name, index)
     context[name, index] = label
 end
@@ -1473,6 +1471,7 @@ function add_constant_node!(model::Model, context::Context, options::NodeCreatio
 end
 
 function __add_variable_node!(model::Model, context::Context, options::NodeCreationOptions, name::Symbol, index)
+    # In theory plugins are able to overwrite this
     potential_label = generate_nodelabel(model, name)
     potential_nodedata = NodeData(context, convert(VariableNodeProperties, name, index, options))
     label, nodedata = preprocess_plugins(

--- a/test/graph_construction_tests.jl
+++ b/test/graph_construction_tests.jl
@@ -1678,7 +1678,6 @@ end
     include("testutils.jl")
 
     @model function neural_dot(out, in, w)
-        local c
         c[1] ~ in[1] * w[1]
         for i in 2:length(in)
             c[i] ~ c[i - 1] + in[i] * w[i]


### PR DESCRIPTION
This PR addresses a bug found by @FraserP117 in #233 where constants increased the model counter twice and got two appendices for the NodeLabel. This implementation is a bit clunky, but it does the job.