### PR TITLE
Give a hint if a user uses = operator wrong

### DIFF
--- a/src/GraphPPL.jl
+++ b/src/GraphPPL.jl
@@ -50,4 +50,20 @@ macro model(model_specification)
     return esc(GraphPPL.model_macro_interior(DefaultBackend, model_specification))
 end
 
+function __init__()
+    if isdefined(Base.Experimental, :register_error_hint)
+        Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
+            if any(x -> x <: VariableRef, argtypes)
+                print(io, "\nOne of the arguments to ")
+                printstyled(io, "`$(exc.f)`", color = :cyan)
+                print(io, " is of type ")
+                printstyled(io, "`GraphPPL.VariableRef`", color = :cyan)
+                print(io, ". Did you mean to create a new random variable with ")
+                printstyled(io, "`:=`", color = :cyan)
+                print(io, " operator instead?")
+            end
+        end
+    end
+end
+
 end # module

--- a/test/model_macro_tests.jl
+++ b/test/model_macro_tests.jl
@@ -2030,3 +2030,16 @@ end
 
     @test !isnothing(GraphPPL.create_model(somemodel(a = 1, b = 2)))
 end
+
+@testitem "model should warn users against incorrect usages of `=` operator with random variables" begin 
+    using GraphPPL, Distributions
+    import GraphPPL: @model
+
+    @model function somemodel()
+        a ~ Normal(0, 1)
+        t = exp(a)
+        y ~ Normal(0, t)
+    end
+
+    @test_throws "One of the arguments to `exp` is of type `GraphPPL.VariableRef`. Did you mean to create a new random variable with `:=` operator instead?" GraphPPL.create_model(somemodel())
+end


### PR DESCRIPTION
This pull request introduces an error hint mechanism to guide users towards correct usage of the `:=` operator when creating new random variables and adds a corresponding test to ensure this functionality works as expected.

### Error hint mechanism:
* [`src/GraphPPL.jl`](diffhunk://#diff-f882d3833959142b2fe2b34972ee335344fca1715059652f838da5d60ee93127R53-R68): Added an initialization function `__init__` to register an error hint for `MethodError` when `VariableRef` is used incorrectly, suggesting the use of the `:=` operator instead.

### Testing:
* [`test/model_macro_tests.jl`](diffhunk://#diff-d197d68d784bc5b1b2ca5a93f4529bc1ec682824a46476bbe2e20e8a75ea5caaR2033-R2045): Added a test case to verify that the error hint is triggered when a `VariableRef` is used incorrectly with the `=` operator.