### PR TITLE
Refine factor, variable and edge interfaces

### DIFF
--- a/src/GraphPPL.jl
+++ b/src/GraphPPL.jl
@@ -37,6 +37,7 @@ include("model/core/node_labels.jl")
 
 include("model/core/variable_node_data.jl")
 include("model/core/factor_node_data.jl")
+include("model/core/edge_node_data.jl")
 include("model/core/anonymous_variable.jl")
 
 include("plugins/plugins_collection.jl")

--- a/src/interfaces/edge_interface.jl
+++ b/src/interfaces/edge_interface.jl
@@ -51,10 +51,18 @@ function set_extra!(edge::E, key, value) where {E <: EdgeInterface}
 end
 
 """
-    Base.show(io, edge::EdgeInterface)
+    create_edge_data(::Type{T}, name, index)
 
-Display a string representation of the edge.
+Create edge data for the given model, name, and index.
+
+# Arguments
+- `model`: The factor graph model interface instance
+- `name`: The name of the edge
+- `index`: The index of the edge
+
+# Returns
+- An instance of edge data that implements `EdgeDataInterface`
 """
-function Base.show(io, edge::E) where {E <: EdgeInterface}
-    throw(GraphPPLInterfaceNotImplemented(show, E, EdgeInterface))
+function create_edge_data(::Type{T}, name, index) where {T <: EdgeDataInterface}
+    throw(GraphPPLInterfaceNotImplemented(create_edge_data, T, EdgeDataInterface))
 end

--- a/src/interfaces/edge_interface.jl
+++ b/src/interfaces/edge_interface.jl
@@ -1,68 +1,103 @@
 """
-    EdgeInterface
+    EdgeDataInterface
 
 Abstract interface for edges in a factor graph. Represents the connection
 between nodes and its properties.
 """
-abstract type EdgeInterface end
+abstract type EdgeDataInterface end
 
 """
-    get_name(edge::EdgeInterface)
+    get_name(edge::E) where {E<:EdgeDataInterface}
 
 Get the name of the edge.
-"""
-function get_name end
-
-"""
-    get_index(edge::EdgeInterface)
-
-Get the index of the edge.
-"""
-function get_index end
-
-"""
-    has_extra(edge::EdgeInterface, key::Symbol)
-    has_extra(edge::EdgeInterface, key::NodeDataExtraKey)
-
-Check if the edge has an extra property with the given key.
-"""
-function has_extra(edge::E, key) where {E <: EdgeInterface}
-    throw(GraphPPLInterfaceNotImplemented(has_extra, E, EdgeInterface))
-end
-
-"""
-    get_extra(edge::EdgeInterface, key)
-    get_extra(edge::EdgeInterface, key, default)
-
-Get the extra property with the given key. If a form with a default value is used and the property
-does not exist, returns the default value. The NodeDataExtraKey versions provide type safety at compile time.
-"""
-function get_extra(edge::E, args...) where {E <: EdgeInterface}
-    throw(GraphPPLInterfaceNotImplemented(get_extra, E, EdgeInterface))
-end
-
-"""
-    set_extra!(edge::EdgeInterface, key::Symbol, value)
-
-Set the extra property with the given key to the given value.
-"""
-function set_extra!(edge::E, key, value) where {E <: EdgeInterface}
-    throw(GraphPPLInterfaceNotImplemented(set_extra!, E, EdgeInterface))
-end
-
-"""
-    create_edge_data(::Type{T}, name, index)
-
-Create edge data for the given model, name, and index.
 
 # Arguments
-- `model`: The factor graph model interface instance
+- `edge`: The edge data to query
+
+# Returns
+The name associated with this edge
+"""
+function get_name(::E) where {E <: EdgeDataInterface}
+    throw(GraphPPLInterfaceNotImplemented(get_name, E, EdgeDataInterface))
+end
+
+"""
+    get_index(edge::E) where {E<:EdgeDataInterface}
+
+Get the index of the edge.
+
+# Arguments
+- `edge`: The edge data to query
+
+# Returns
+The index associated with this edge
+"""
+function get_index(::E) where {E <: EdgeDataInterface}
+    throw(GraphPPLInterfaceNotImplemented(get_index, E, EdgeDataInterface))
+end
+
+"""
+    has_extra(edge::E, key) where {E<:EdgeDataInterface}
+
+Check if the edge has an extra property with the given key.
+
+# Arguments
+- `edge`: The edge data to check
+- `key`: The key to look up in the extra properties
+
+# Returns
+`true` if the extra property exists, `false` otherwise
+"""
+function has_extra(::E, key) where {E <: EdgeDataInterface}
+    throw(GraphPPLInterfaceNotImplemented(has_extra, E, EdgeDataInterface))
+end
+
+"""
+    get_extra(edge::E, key) where {E<:EdgeDataInterface}
+    get_extra(edge::E, key, default) where {E<:EdgeDataInterface}
+
+Get the extra property with the given key. If a form with a default value is used and the property
+does not exist, returns the default value.
+
+# Arguments
+- `edge`: The edge data to query
+- `key`: The key to look up in the extra properties
+- `default`: Optional default value to return if the key doesn't exist
+
+# Returns
+The value associated with the key, or the default value if provided and the key doesn't exist
+"""
+function get_extra(::E, args...) where {E <: EdgeDataInterface}
+    throw(GraphPPLInterfaceNotImplemented(get_extra, E, EdgeDataInterface))
+end
+
+"""
+    set_extra!(edge::E, key, value) where {E<:EdgeDataInterface}
+
+Set the extra property with the given key to the given value.
+
+# Arguments
+- `edge`: The edge data to modify
+- `key`: The key to set in the extra properties
+- `value`: The value to associate with the key
+"""
+function set_extra!(::E, key, value) where {E <: EdgeDataInterface}
+    throw(GraphPPLInterfaceNotImplemented(set_extra!, E, EdgeDataInterface))
+end
+
+"""
+    create_edge_data(::Type{T}; name, index) where {T<:EdgeDataInterface}
+
+Create edge data with the given name and index.
+
+# Arguments
+- `::Type{T}`: The concrete type of edge data to create
 - `name`: The name of the edge
 - `index`: The index of the edge
 
 # Returns
-- An instance of edge data that implements `EdgeDataInterface`
+An instance of type T containing the edge data
 """
-function create_edge_data(::Type{T}, name, index) where {T <: EdgeDataInterface}
+function create_edge_data(::Type{T}; name, index) where {T <: EdgeDataInterface}
     throw(GraphPPLInterfaceNotImplemented(create_edge_data, T, EdgeDataInterface))
 end

--- a/src/interfaces/factor_interface.jl
+++ b/src/interfaces/factor_interface.jl
@@ -7,78 +7,78 @@ for a factor node in the model. Models can implement specific types that extend 
 abstract type FactorNodeDataInterface end
 
 """
-    get_functional_form(factor_data::FactorNodeDataInterface)
+    get_functional_form(factor_data::F) where {F<:FactorNodeDataInterface}
 
 Get the functional form of the factor node data.
+
+# Returns
+The functional form associated with this factor node.
 """
-function get_functional_form(factor_data::F) where {F <: FactorNodeDataInterface}
+function get_functional_form(::F) where {F <: FactorNodeDataInterface}
     throw(GraphPPLInterfaceNotImplemented(get_functional_form, F, FactorNodeDataInterface))
 end
 
 """
-    get_context(factor_data::FactorNodeDataInterface)
-
-Get the context associated with the factor node data.
-"""
-function get_context(factor_data::F) where {F <: FactorNodeDataInterface}
-    throw(GraphPPLInterfaceNotImplemented(get_context, F, FactorNodeDataInterface))
-end
-
-"""
-    has_extra(factor_data::FactorNodeDataInterface, key)
+    has_extra(factor_data::F, key) where {F<:FactorNodeDataInterface}
 
 Check if the factor node data has an extra property with the given key.
+
+# Arguments
+- `factor_data`: The factor node data to check
+- `key`: The key to look up in the extra properties
+
+# Returns
+`true` if the extra property exists, `false` otherwise
 """
-function has_extra(factor_data::F, key) where {F <: FactorNodeDataInterface}
+function has_extra(::F, key) where {F <: FactorNodeDataInterface}
     throw(GraphPPLInterfaceNotImplemented(has_extra, F, FactorNodeDataInterface))
 end
 
 """
-    get_extra(factor_data::FactorNodeDataInterface, key)
-    get_extra(factor_data::FactorNodeDataInterface, key, default)
+    get_extra(factor_data::F, key) where {F<:FactorNodeDataInterface}
+    get_extra(factor_data::F, key, default) where {F<:FactorNodeDataInterface}
 
 Get the extra property with the given key. If a form with a default value is used and the property
-does not exist, returns the default value. The NodeDataExtraKey versions provide type safety at compile time.
+does not exist, returns the default value.
+
+# Arguments
+- `factor_data`: The factor node data to query
+- `key`: The key to look up in the extra properties
+- `default`: Optional default value to return if the key doesn't exist
+
+# Returns
+The value associated with the key, or the default value if provided and the key doesn't exist
 """
-function get_extra(factor_data::F, args...) where {F <: FactorNodeDataInterface}
+function get_extra(::F, args...) where {F <: FactorNodeDataInterface}
     throw(GraphPPLInterfaceNotImplemented(get_extra, F, FactorNodeDataInterface))
 end
 
 """
-    set_extra!(factor_data::FactorNodeDataInterface, key, value)
+    set_extra!(factor_data::F, key, value) where {F<:FactorNodeDataInterface}
 
 Set the extra property with the given key to the given value.
+
+# Arguments
+- `factor_data`: The factor node data to modify
+- `key`: The key to set in the extra properties
+- `value`: The value to associate with the key
 """
-function set_extra!(factor_data::F, key, value) where {F <: FactorNodeDataInterface}
+function set_extra!(::F, key, value) where {F <: FactorNodeDataInterface}
     throw(GraphPPLInterfaceNotImplemented(set_extra!, F, FactorNodeDataInterface))
 end
 
 """
-    Base.show(io, factor_data::FactorNodeDataInterface)
+    create_factor_data(::Type{T}; functional_form) where {T<:FactorNodeDataInterface}
 
-Display a string representation of the factor node data.
-"""
-function Base.show(io, factor_data::F) where {F <: FactorNodeDataInterface}
-    throw(GraphPPLInterfaceNotImplemented(show, F, FactorNodeDataInterface))
-end
-
-"""
-    create_factor_data(model::FactorGraphModelInterface, context, fform; kwargs...)
-
-Create factor node data for the given model, context, and functional form. Additional keyword arguments
-can be provided to customize the factor node data creation.
+Create factor node data for the given functional form.
 
 # Arguments
-- `model`: The factor graph model interface instance
-- `context`: The context for the factor node
-- `fform`: The functional form for the factor node
-
-# Keywords
-- `kwargs...`: Additional keyword arguments for customizing the factor node data
+- `::Type{T}`: The concrete type of factor node data to create
+- `functional_form`: The functional form for the factor node
 
 # Returns
-- An instance of factor node data that implements `FactorNodeDataInterface`
+An instance of type T containing the factor node data
 """
-function create_factor_data(::Type{T}, context::Any, fform::Any; kwargs...) where {T <: FactorNodeDataInterface}
+function create_factor_data(::Type{T}; functional_form) where {T <: FactorNodeDataInterface}
     throw(GraphPPLInterfaceNotImplemented(create_factor_data, T, FactorNodeDataInterface))
 end

--- a/src/interfaces/model_interface.jl
+++ b/src/interfaces/model_interface.jl
@@ -121,14 +121,14 @@ function add_factor!(model::M, data::FactorNodeDataInterface) where {M <: Factor
 end
 
 """
-    add_edge!(model::M, source::NodeLabelInterface, destination::NodeLabelInterface, edge_data::EdgeInterface) where {M<:FactorGraphModelInterface}
+    add_edge!(model::M, source::NodeLabelInterface, destination::NodeLabelInterface, edge_data::EdgeDataInterface) where {M<:FactorGraphModelInterface}
 
 Connect two nodes in the model with an edge containing the specified data.
 
 Returns a reference to the created edge.
 """
 function add_edge!(
-    model::M, source::NodeLabelInterface, destination::NodeLabelInterface, edge_data::EdgeInterface
+    model::M, source::NodeLabelInterface, destination::NodeLabelInterface, edge_data::EdgeDataInterface
 ) where {M <: FactorGraphModelInterface}
     throw(GraphPPLInterfaceNotImplemented(add_edge!, M, FactorGraphModelInterface))
 end
@@ -369,7 +369,7 @@ end
     get_edge_data_type(model::M) where {M <: FactorGraphModelInterface}
 
 Returns the type of edge data used by this model implementation.
-Must return a type that implements EdgeInterface.
+Must return a type that implements EdgeDataInterface.
 """
 function get_edge_data_type(model::M) where {M <: FactorGraphModelInterface}
     throw(GraphPPLInterfaceNotImplemented(get_edge_data_type, M, FactorGraphModelInterface))
@@ -387,7 +387,7 @@ This payload is intended to be passed to `GraphPPL.add_edge!(model, source, dest
 - `index::Any`: An index, if the edge connects to an indexed interface (e.g., for vector-valued arguments).
 
 # Returns
-- An instance of a concrete edge data structure (which should be a subtype of `EdgeInterface`).
+- An instance of a concrete edge data structure (which should be a subtype of `EdgeDataInterface`).
 """
 function create_edge_data(model::M, name::Symbol, index::Any) where {M <: FactorGraphModelInterface}
     T = get_edge_data_type(model)

--- a/src/interfaces/plugins_interface.jl
+++ b/src/interfaces/plugins_interface.jl
@@ -73,12 +73,12 @@ function preprocess_plugin(
 end
 
 """
-    preprocess_plugin(plugin, model::FactorGraphModelInterface, context::ContextInterface, edgedata::EdgeInterface)
+    preprocess_plugin(plugin, model::FactorGraphModelInterface, context::ContextInterface, edgedata::EdgeDataInterface)
 
 Call a plugin specific logic for an edge upon its creation.
 """
 function preprocess_plugin(
-    plugin::P, model::FactorGraphModelInterface, context::ContextInterface, edgedata::EdgeInterface
+    plugin::P, model::FactorGraphModelInterface, context::ContextInterface, edgedata::EdgeDataInterface
 ) where {P <: PluginInterface}
     throw(GraphPPLInterfaceNotImplemented(preprocess_plugin, P, PluginInterface))
 end

--- a/src/interfaces/variable_interface.jl
+++ b/src/interfaces/variable_interface.jl
@@ -6,29 +6,13 @@ for a variable node in the model. Models can implement specific types that exten
 """
 abstract type VariableNodeDataInterface end
 
-"""
-    create_variable_data(::Type{T}, name::Symbol, index::Any, kind::Symbol, link::Any, value::Any, context::Any, metadata::Any=nothing) where {T<:VariableNodeDataInterface}
-
-Template constructor for variable node data. Implementations can specialize on T to provide
-different construction logic for different node data types.
-
-# Arguments
-- `::Type{T}`: The concrete type of node data to create
-- `name::Symbol`: The name of the variable
-- `index::Any`: The index associated with the variable (nothing for non-indexed)
-- `kind::Symbol`: The kind of variable (e.g. :random, :data, :constant)
-- `link::Any`: Optional link to other nodes/components
-- `value::Any`: Optional pre-assigned value
-- `context::Any`: The context in which this variable exists
-- `metadata::Any`: Optional additional metadata for extensions
-
-# Returns
-An instance of type T containing the variable node data
-"""
-function create_variable_data(
-    ::Type{T}, name::Symbol, index::Any, kind::Symbol, link::Any, value::Any, context::Any, metadata::Any = nothing
-) where {T <: VariableNodeDataInterface}
-    throw(GraphPPLInterfaceNotImplemented(create_variable_data, T, VariableNodeDataInterface))
+module VariableNodeKind
+const Unspecified::UInt8 = UInt8(0x00)
+const Random::UInt8 = UInt8(0x01)
+const Data::UInt8 = UInt8(0x02)
+const Constant::UInt8 = UInt8(0x03)
+const Anonymous::UInt8 = UInt8(0x04)
+const Unknown::UInt8 = UInt8(0x05)
 end
 
 """
@@ -36,7 +20,7 @@ end
 
 Get the name of the variable node data.
 """
-function get_name(variable_data::V) where {V <: VariableNodeDataInterface}
+function get_name(::V) where {V <: VariableNodeDataInterface}
     throw(GraphPPLInterfaceNotImplemented(get_name, V, VariableNodeDataInterface))
 end
 
@@ -45,7 +29,7 @@ end
 
 Get the index of the variable node data.
 """
-function get_index(variable_data::V) where {V <: VariableNodeDataInterface}
+function get_index(::V) where {V <: VariableNodeDataInterface}
     throw(GraphPPLInterfaceNotImplemented(get_index, V, VariableNodeDataInterface))
 end
 
@@ -54,16 +38,16 @@ end
 
 Get the link of the variable node data.
 """
-function get_link(variable_data::V) where {V <: VariableNodeDataInterface}
+function get_link(::V) where {V <: VariableNodeDataInterface}
     throw(GraphPPLInterfaceNotImplemented(get_link, V, VariableNodeDataInterface))
 end
 
 """
     get_kind(variable_data::V) where {V<:VariableNodeDataInterface}
 
-Get the kind of the variable node data.
+Get the kind of the variable node data. Must return a value from the `VariableNodeKind` module.
 """
-function get_kind(variable_data::V) where {V <: VariableNodeDataInterface}
+function get_kind(::V) where {V <: VariableNodeDataInterface}
     throw(GraphPPLInterfaceNotImplemented(get_kind, V, VariableNodeDataInterface))
 end
 
@@ -72,8 +56,17 @@ end
 
 Get the value of the variable node data.
 """
-function get_value(variable_data::V) where {V <: VariableNodeDataInterface}
+function get_value(::V) where {V <: VariableNodeDataInterface}
     throw(GraphPPLInterfaceNotImplemented(get_value, V, VariableNodeDataInterface))
+end
+
+"""
+    is_kind(variable_data::V, kind::UInt8) where {V <: VariableNodeDataInterface}
+
+Check if the variable node data is of the given kind.
+"""
+function is_kind(variable_data::V, kind::UInt8) where {V <: VariableNodeDataInterface}
+    return get_kind(variable_data) === kind
 end
 
 """
@@ -82,7 +75,7 @@ end
 Check if the variable node data is random.
 """
 function is_random(variable_data::V) where {V <: VariableNodeDataInterface}
-    throw(GraphPPLInterfaceNotImplemented(is_random, V, VariableNodeDataInterface))
+    return is_kind(variable_data, VariableNodeKind.Random)
 end
 
 """
@@ -91,7 +84,7 @@ end
 Check if the variable node data is data.
 """
 function is_data(variable_data::V) where {V <: VariableNodeDataInterface}
-    throw(GraphPPLInterfaceNotImplemented(is_data, V, VariableNodeDataInterface))
+    return is_kind(variable_data, VariableNodeKind.Data)
 end
 
 """
@@ -100,7 +93,7 @@ end
 Check if the variable node data is constant.
 """
 function is_constant(variable_data::V) where {V <: VariableNodeDataInterface}
-    throw(GraphPPLInterfaceNotImplemented(is_constant, V, VariableNodeDataInterface))
+    return is_kind(variable_data, VariableNodeKind.Constant)
 end
 
 """
@@ -109,17 +102,7 @@ end
 Check if the variable node data is anonymous.
 """
 function is_anonymous(variable_data::V) where {V <: VariableNodeDataInterface}
-    throw(GraphPPLInterfaceNotImplemented(is_anonymous, V, VariableNodeDataInterface))
-end
-
-"""
-
-    get_context(variable_data::V) where {V<:VariableNodeDataInterface}
-
-Get the context associated with the variable node data.
-"""
-function get_context(variable_data::V) where {V <: VariableNodeDataInterface}
-    throw(GraphPPLInterfaceNotImplemented(get_context, V, VariableNodeDataInterface))
+    return is_kind(variable_data, VariableNodeKind.Anonymous)
 end
 
 """
@@ -127,19 +110,18 @@ end
 
 Check if the variable node data has an extra property with the given key.
 """
-function has_extra(variable_data::V, key) where {V <: VariableNodeDataInterface}
+function has_extra(::V, key) where {V <: VariableNodeDataInterface}
     throw(GraphPPLInterfaceNotImplemented(has_extra, V, VariableNodeDataInterface))
 end
 
 """
-    get_extra(variable_data::V) where {V<:VariableNodeDataInterface}
     get_extra(variable_data::V, key) where {V<:VariableNodeDataInterface}
     get_extra(variable_data::V, key, default) where {V<:VariableNodeDataInterface}
 
 Get the extra property with the given key. If a form with a default value is used and the property
 does not exist, returns the default value.
 """
-function get_extra(variable_data::V, args...) where {V <: VariableNodeDataInterface}
+function get_extra(::V, args...) where {V <: VariableNodeDataInterface}
     throw(GraphPPLInterfaceNotImplemented(get_extra, V, VariableNodeDataInterface))
 end
 
@@ -148,6 +130,29 @@ end
 
 Set the extra property with the given key to the given value.
 """
-function set_extra!(variable_data::V, key, value) where {V <: VariableNodeDataInterface}
+function set_extra!(::V, key, value) where {V <: VariableNodeDataInterface}
     throw(GraphPPLInterfaceNotImplemented(set_extra!, V, VariableNodeDataInterface))
+end
+
+"""
+    create_variable_data(::Type{T}; name::Symbol, index::Any, kind::UInt8 = VariableNodeKind.Unspecified, link::Any = nothing, value::Any = nothing) where {T<:VariableNodeDataInterface}
+
+Template constructor for variable node data. Implementations can specialize on T to provide
+different construction logic for different node data types.
+
+# Arguments
+- `::Type{T}`: The concrete type of node data to create
+- `name::Symbol`: The name of the variable
+- `index::Any`: The index associated with the variable (nothing for non-indexed)
+- `kind::UInt8`: The kind of variable (see VariableNodeKind module)
+- `link::Any`: Optional link to other nodes/components
+- `value::Any`: Optional pre-assigned value
+
+# Returns
+An instance of type T containing the variable node data
+"""
+function create_variable_data(
+    ::Type{T}; name::Symbol, index::Any, kind::Symbol = VariableNodeKind.Unspecified, link::Any = nothing, value::Any = nothing
+) where {T <: VariableNodeDataInterface}
+    throw(GraphPPLInterfaceNotImplemented(create_variable_data, T, VariableNodeDataInterface))
 end

--- a/src/model/core/bipartitemodel.jl
+++ b/src/model/core/bipartitemodel.jl
@@ -58,7 +58,7 @@ function add_factor!(model::BipartiteModel, data::FactorNodeDataInterface)
     return BipartiteFactorGraphs.add_factor!(model.graph, data)
 end
 
-function add_edge!(model::BipartiteModel, source::NodeLabelInterface, destination::NodeLabelInterface, edge_data::EdgeInterface)
+function add_edge!(model::BipartiteModel, source::NodeLabelInterface, destination::NodeLabelInterface, edge_data::EdgeDataInterface)
     return BipartiteFactorGraphs.add_edge!(
         model.graph, __prepare_node_label(model, source), __prepare_node_label(model, destination), edge_data
     )

--- a/src/model/core/edge_node_data.jl
+++ b/src/model/core/edge_node_data.jl
@@ -1,0 +1,102 @@
+"""
+    EdgeNodeData
+
+A concrete implementation of `EdgeDataInterface` that stores data for an edge in the factor graph.
+
+# Fields
+- `name::Symbol`: The name of the edge
+- `index::Any = nothing`: The index of the edge
+- `extras::Dict{Symbol, Any} = Dict{Symbol, Any}()`: Dictionary for storing additional properties
+"""
+@kwdef struct EdgeNodeData <: EdgeDataInterface
+    name::Symbol
+    index::Any = nothing
+    extras::Dict{Symbol, Any} = Dict{Symbol, Any}()
+end
+
+# Interface implementation
+get_name(edge::EdgeNodeData) = edge.name
+get_index(edge::EdgeNodeData) = edge.index
+
+"""
+    has_extra(edge::EdgeNodeData, key::Symbol)
+
+Check if the edge has an extra property with the given key.
+"""
+function has_extra(edge::EdgeNodeData, key::Symbol)
+    return haskey(edge.extras, key)
+end
+
+"""
+    has_extra(edge::EdgeNodeData, key::CompileTimeDictionaryKey)
+
+Check if the edge has an extra property with the given key.
+"""
+function has_extra(edge::EdgeNodeData, key::CompileTimeDictionaryKey{K, T}) where {K, T}
+    return haskey(edge.extras, get_key(key))
+end
+
+"""
+    get_extra(edge::EdgeNodeData, key::Symbol)
+
+Get the extra property with the given key.
+"""
+function get_extra(edge::EdgeNodeData, key::Symbol)
+    return edge.extras[key]
+end
+
+"""
+    get_extra(edge::EdgeNodeData, key::CompileTimeDictionaryKey)
+
+Get the extra property with the given key.
+"""
+function get_extra(edge::EdgeNodeData, key::CompileTimeDictionaryKey{K, T}) where {K, T}
+    return convert(T, edge.extras[get_key(key)])::T
+end
+
+"""
+    get_extra(edge::EdgeNodeData, key::Symbol, default)
+
+Get the extra property with the given key. If the property does not exist, returns the default value.
+"""
+function get_extra(edge::EdgeNodeData, key::Symbol, default)
+    return get(edge.extras, key, default)
+end
+
+"""
+    get_extra(edge::EdgeNodeData, key::CompileTimeDictionaryKey, default)
+
+Get the extra property with the given key. If the property does not exist, returns the default value.
+"""
+function get_extra(edge::EdgeNodeData, key::CompileTimeDictionaryKey{K, T}, default) where {K, T}
+    return convert(T, get(edge.extras, get_key(key), default))::T
+end
+
+"""
+    set_extra!(edge::EdgeNodeData, key::Symbol, value)
+
+Set the extra property with the given key to the given value.
+"""
+function set_extra!(edge::EdgeNodeData, key::Symbol, value)
+    edge.extras[key] = value
+    return value
+end
+
+"""
+    set_extra!(edge::EdgeNodeData, key::CompileTimeDictionaryKey, value)
+
+Set the extra property with the given key to the given value.
+"""
+function set_extra!(edge::EdgeNodeData, key::CompileTimeDictionaryKey{K, T}, value::T) where {K, T}
+    edge.extras[get_key(key)] = value
+    return value
+end
+
+"""
+    create_edge_data(::Type{EdgeNodeData}; name::Symbol, index::Any = nothing)
+
+Create a new edge data of type `EdgeNodeData` with the given parameters.
+"""
+function create_edge_data(::Type{EdgeNodeData}; name::Symbol, index::Any = nothing)
+    return EdgeNodeData(name = name, index = index)
+end 

--- a/src/model/core/factor_node_data.jl
+++ b/src/model/core/factor_node_data.jl
@@ -2,25 +2,14 @@
     FactorNodeData <: FactorNodeDataInterface
 
 Concrete implementation of `FactorNodeDataInterface` that stores data for a factor node in a factor graph.
+
+# Fields
+- `functional_form::Any`: The functional form of the factor node
+- `extras::Dict{Symbol, Any}`: Dictionary for storing additional properties
 """
-struct FactorNodeData <: FactorNodeDataInterface
-    """Functional form of the factor node."""
-    form::Any
-
-    """Context associated with the factor node."""
-    context::Any
-
-    """Dictionary of extra properties associated with the factor node."""
-    extras::Dict{Symbol, Any}
-
-    """
-        FactorNodeData(form, context = nothing)
-
-    Create a new factor node data with the given functional form and optional context.
-    """
-    function FactorNodeData(form, context = nothing)
-        new(form, context, Dict{Symbol, Any}())
-    end
+Base.@kwdef struct FactorNodeData <: FactorNodeDataInterface
+    functional_form::Any
+    extras::Dict{Symbol, Any} = Dict{Symbol, Any}()
 end
 
 """
@@ -29,16 +18,7 @@ end
 Get the functional form of the factor node data.
 """
 function get_functional_form(factor_data::FactorNodeData)
-    return factor_data.form
-end
-
-"""
-    get_context(factor_data::FactorNodeData)
-
-Get the context associated with the factor node data.
-"""
-function get_context(factor_data::FactorNodeData)
-    return factor_data.context
+    return factor_data.functional_form
 end
 
 """
@@ -74,7 +54,7 @@ end
 Get the extra property with the given key.
 """
 function get_extra(factor_data::FactorNodeData, key::CompileTimeDictionaryKey{K, T}) where {K, T}
-    return factor_data.extras[get_key(key)]::T
+    return convert(T, factor_data.extras[get_key(key)])::T
 end
 
 """
@@ -92,7 +72,7 @@ end
 Get the extra property with the given key. If the property does not exist, returns the default value.
 """
 function get_extra(factor_data::FactorNodeData, key::CompileTimeDictionaryKey{K, T}, default) where {K, T}
-    return get(factor_data.extras, get_key(key), default)::T
+    return convert(T, get(factor_data.extras, get_key(key), default))::T
 end
 
 """
@@ -116,14 +96,10 @@ function set_extra!(factor_data::FactorNodeData, key::CompileTimeDictionaryKey{K
 end
 
 """
-    Base.show(io::IO, data::FactorNodeData)
+    create_factor_data(::Type{FactorNodeData}; functional_form)
 
-Custom display method for FactorNodeData.
+Create a new factor node data of type `FactorNodeData` with the given functional form.
 """
-function Base.show(io::IO, data::FactorNodeData)
-    print(io, "FactorNodeData(form=$(data.form), context=$(data.context), extras=$(data.extras))")
-end
-
-function create_factor_data(::Type{FactorNodeData}, context::Any, fform::Any; kwargs...)
-    return FactorNodeData(fform, context)
+function create_factor_data(::Type{FactorNodeData}; functional_form)
+    return FactorNodeData(functional_form = functional_form)
 end

--- a/test/model/core/edge_node_data_tests.jl
+++ b/test/model/core/edge_node_data_tests.jl
@@ -1,0 +1,186 @@
+@testitem "EdgeNodeData creation with `create_edge_data`" begin
+    import GraphPPL: EdgeNodeData, get_name, get_index, create_edge_data
+
+    # Test basic creation
+    edge = create_edge_data(EdgeNodeData, name = :test)
+    @test @inferred(get_name(edge)) === :test
+    @test @inferred(get_index(edge)) === nothing
+
+    # Test with all fields
+    edge = create_edge_data(EdgeNodeData, name = :full_test, index = 2)
+    @test get_name(edge) === :full_test
+    @test get_index(edge) === 2
+end
+
+@testitem "EdgeNodeData implements has_extra with Symbol keys" begin
+    import GraphPPL: EdgeNodeData, has_extra, get_extra, set_extra!, create_edge_data
+
+    edge = create_edge_data(EdgeNodeData, name = :test)
+
+    # Initially, no extras should exist
+    @test !has_extra(edge, :test_key)
+
+    # After setting an extra, it should exist
+    set_extra!(edge, :test_key, "test_value")
+    @test has_extra(edge, :test_key)
+    @test get_extra(edge, :test_key) == "test_value"
+
+    # Non-existent keys should return false
+    @test !has_extra(edge, :nonexistent_key)
+end
+
+@testitem "EdgeNodeData implements has_extra with CompileTimeDictionaryKey" begin
+    import GraphPPL: EdgeNodeData, has_extra, set_extra!, CompileTimeDictionaryKey, create_edge_data
+
+    edge = create_edge_data(EdgeNodeData, name = :test)
+    key = CompileTimeDictionaryKey{:test_key, String}()
+
+    # Initially, no extras should exist
+    @test !has_extra(edge, key)
+
+    # After setting an extra, it should exist
+    set_extra!(edge, key, "test_value")
+    @test has_extra(edge, key)
+
+    # Different key should not exist
+    other_key = CompileTimeDictionaryKey{:other_key, Int}()
+    @test !has_extra(edge, other_key)
+end
+
+@testitem "EdgeNodeData implements get_extra with Symbol keys" begin
+    import GraphPPL: EdgeNodeData, get_extra, set_extra!, create_edge_data
+
+    edge = create_edge_data(EdgeNodeData, name = :test)
+
+    # Set and get an extra
+    set_extra!(edge, :test_key, "test_value")
+    @test get_extra(edge, :test_key) == "test_value"
+
+    # Get with default for existing key
+    @test get_extra(edge, :test_key, "default") == "test_value"
+
+    # Get with default for non-existent key
+    @test get_extra(edge, :nonexistent_key, "default") == "default"
+
+    # Getting non-existent key without default should throw
+    @test_throws KeyError get_extra(edge, :nonexistent_key)
+end
+
+@testitem "EdgeNodeData implements get_extra with CompileTimeDictionaryKey" begin
+    import GraphPPL: EdgeNodeData, get_extra, set_extra!, CompileTimeDictionaryKey, create_edge_data
+
+    edge = create_edge_data(EdgeNodeData, name = :test)
+    string_key = CompileTimeDictionaryKey{:string_key, String}()
+    int_key = CompileTimeDictionaryKey{:int_key, Int}()
+
+    # Set and get extras with type safety
+    set_extra!(edge, string_key, "test_value")
+    set_extra!(edge, int_key, 42)
+
+    @test @inferred(get_extra(edge, string_key)) == "test_value"
+    @test @inferred(get_extra(edge, int_key)) == 42
+
+    # Get with default for existing key
+    @test @inferred(get_extra(edge, string_key, "default")) == "test_value"
+    @test @inferred(get_extra(edge, int_key, 0)) == 42
+
+    # Get with default for non-existent key
+    float_key = CompileTimeDictionaryKey{:float_key, Float64}()
+    @test get_extra(edge, float_key, 3.14) == 3.14
+
+    # Type safety check - should return the correct type
+    @test get_extra(edge, int_key) isa Int
+    @test get_extra(edge, string_key) isa String
+end
+
+@testitem "EdgeNodeData implements set_extra! with Symbol keys" begin
+    import GraphPPL: EdgeNodeData, get_extra, set_extra!, create_edge_data
+
+    edge = create_edge_data(EdgeNodeData, name = :test)
+
+    # Set a new extra
+    @test set_extra!(edge, :test_key, "test_value") == "test_value"
+    @test get_extra(edge, :test_key) == "test_value"
+
+    # Overwrite an existing extra
+    @test set_extra!(edge, :test_key, "new_value") == "new_value"
+    @test get_extra(edge, :test_key) == "new_value"
+
+    # Set extras of different types
+    @test set_extra!(edge, :int_key, 42) == 42
+    @test set_extra!(edge, :bool_key, true) == true
+
+    @test get_extra(edge, :int_key) == 42
+    @test get_extra(edge, :bool_key) == true
+end
+
+@testitem "EdgeNodeData implements set_extra! with CompileTimeDictionaryKey" begin
+    import GraphPPL: EdgeNodeData, get_extra, set_extra!, CompileTimeDictionaryKey, create_edge_data
+
+    edge = create_edge_data(EdgeNodeData, name = :test)
+    string_key = CompileTimeDictionaryKey{:string_key, String}()
+    int_key = CompileTimeDictionaryKey{:int_key, Int}()
+
+    # Set new extras with type safety
+    @test set_extra!(edge, string_key, "test_value") == "test_value"
+    @test set_extra!(edge, int_key, 42) == 42
+
+    @test get_extra(edge, string_key) == "test_value"
+    @test get_extra(edge, int_key) == 42
+
+    # Overwrite existing extras
+    @test set_extra!(edge, string_key, "new_value") == "new_value"
+    @test get_extra(edge, string_key) == "new_value"
+end
+
+@testitem "EdgeNodeData show method" begin
+    import GraphPPL: EdgeNodeData, set_extra!, create_edge_data
+
+    edge = create_edge_data(EdgeNodeData, name = :test)
+    set_extra!(edge, :test_key, "test_value")
+
+    # Test string representation
+    str = sprint(show, edge)
+    @test occursin("EdgeNodeData", str)
+    @test occursin(":test", str)
+    @test occursin("test_key", str)
+    @test occursin("test_value", str)
+end
+
+@testitem "EdgeNodeData satisfies EdgeDataInterface" begin
+    import GraphPPL:
+        EdgeNodeData,
+        EdgeDataInterface,
+        get_name,
+        get_index,
+        has_extra,
+        get_extra,
+        set_extra!,
+        CompileTimeDictionaryKey,
+        create_edge_data
+
+    # Verify EdgeNodeData is a subtype of EdgeDataInterface
+    @test EdgeNodeData <: EdgeDataInterface
+
+    # Create a test instance
+    edge = create_edge_data(EdgeNodeData, name = :test, index = 1)
+
+    # Test all interface methods are implemented
+    @test get_name(edge) === :test
+    @test get_index(edge) === 1
+
+    # Test extras management
+    @test !has_extra(edge, :test_key)
+    set_extra!(edge, :test_key, "test_value")
+    @test has_extra(edge, :test_key)
+    @test get_extra(edge, :test_key) == "test_value"
+    @test get_extra(edge, :nonexistent, "default") == "default"
+
+    # Test CompileTimeDictionaryKey interface
+    key = CompileTimeDictionaryKey{:typed_key, Int}()
+    @test !has_extra(edge, key)
+    set_extra!(edge, key, 42)
+    @test has_extra(edge, key)
+    @test get_extra(edge, key) == 42
+    @test get_extra(edge, CompileTimeDictionaryKey{:nonexistent, Float64}(), 3.14) == 3.14
+end 

--- a/test/model/core/edge_node_data_tests.jl
+++ b/test/model/core/edge_node_data_tests.jl
@@ -3,8 +3,8 @@
 
     # Test basic creation
     edge = create_edge_data(EdgeNodeData, name = :test)
-    @test @inferred(get_name(edge)) === :test
-    @test @inferred(get_index(edge)) === nothing
+    @test get_name(edge) === :test
+    @test get_index(edge) === nothing
 
     # Test with all fields
     edge = create_edge_data(EdgeNodeData, name = :full_test, index = 2)
@@ -149,15 +149,7 @@ end
 
 @testitem "EdgeNodeData satisfies EdgeDataInterface" begin
     import GraphPPL:
-        EdgeNodeData,
-        EdgeDataInterface,
-        get_name,
-        get_index,
-        has_extra,
-        get_extra,
-        set_extra!,
-        CompileTimeDictionaryKey,
-        create_edge_data
+        EdgeNodeData, EdgeDataInterface, get_name, get_index, has_extra, get_extra, set_extra!, CompileTimeDictionaryKey, create_edge_data
 
     # Verify EdgeNodeData is a subtype of EdgeDataInterface
     @test EdgeNodeData <: EdgeDataInterface
@@ -183,4 +175,4 @@ end
     @test has_extra(edge, key)
     @test get_extra(edge, key) == 42
     @test get_extra(edge, CompileTimeDictionaryKey{:nonexistent, Float64}(), 3.14) == 3.14
-end 
+end

--- a/test/model/core/factor_node_data_tests.jl
+++ b/test/model/core/factor_node_data_tests.jl
@@ -1,35 +1,25 @@
-@testitem "FactorNodeData constructor" begin
-    import GraphPPL: FactorNodeData, get_functional_form, get_context
+@testitem "FactorNodeData creation with `create_factor_data`" begin
+    import GraphPPL: FactorNodeData, get_functional_form, create_factor_data
 
-    # Test constructor with form only
-    factor_data = FactorNodeData("test_form")
-    @test get_functional_form(factor_data) == "test_form"
-    @test get_context(factor_data) === nothing
-    @test isempty(factor_data.extras)
-
-    # Test constructor with form and context
-    context = "test_context"
-    factor_data = FactorNodeData("test_form", context)
-    @test get_functional_form(factor_data) == "test_form"
-    @test get_context(factor_data) === context
-    @test isempty(factor_data.extras)
+    for functional_form in ["test_form", "test_form_2", identity, (x) -> x]
+        factor_data = create_factor_data(FactorNodeData, functional_form = functional_form)
+        @test get_functional_form(factor_data) == functional_form
+    end
 end
 
-@testitem "FactorNodeData implements get_functional_form and get_context" begin
-    import GraphPPL: FactorNodeData, get_functional_form, get_context
+@testitem "FactorNodeData implements get_functional_form" begin
+    import GraphPPL: FactorNodeData, get_functional_form, create_factor_data
 
     form = "test_form"
-    context = "test_context"
-    factor_data = FactorNodeData(form, context)
+    factor_data = create_factor_data(FactorNodeData, functional_form = form)
 
     @test get_functional_form(factor_data) === form
-    @test get_context(factor_data) === context
 end
 
 @testitem "FactorNodeData implements has_extra with Symbol keys" begin
-    import GraphPPL: FactorNodeData, has_extra, set_extra!
+    import GraphPPL: FactorNodeData, create_factor_data, has_extra, set_extra!, get_extra
 
-    factor_data = FactorNodeData("test_form")
+    factor_data = create_factor_data(FactorNodeData, functional_form = "test_form")
 
     # Initially, no extras should exist
     @test !has_extra(factor_data, :test_key)
@@ -37,15 +27,16 @@ end
     # After setting an extra, it should exist
     set_extra!(factor_data, :test_key, "test_value")
     @test has_extra(factor_data, :test_key)
+    @test get_extra(factor_data, :test_key) == "test_value"
 
     # Non-existent keys should return false
     @test !has_extra(factor_data, :nonexistent_key)
 end
 
 @testitem "FactorNodeData implements has_extra with CompileTimeDictionaryKey" begin
-    import GraphPPL: FactorNodeData, has_extra, set_extra!, CompileTimeDictionaryKey
+    import GraphPPL: FactorNodeData, has_extra, set_extra!, CompileTimeDictionaryKey, create_factor_data
 
-    factor_data = FactorNodeData("test_form")
+    factor_data = create_factor_data(FactorNodeData, functional_form = "test_form")
     key = CompileTimeDictionaryKey{:test_key, String}()
 
     # Initially, no extras should exist
@@ -61,9 +52,9 @@ end
 end
 
 @testitem "FactorNodeData implements get_extra with Symbol keys" begin
-    import GraphPPL: FactorNodeData, get_extra, set_extra!
+    import GraphPPL: FactorNodeData, get_extra, set_extra!, create_factor_data
 
-    factor_data = FactorNodeData("test_form")
+    factor_data = create_factor_data(FactorNodeData, functional_form = "test_form")
 
     # Set and get an extra
     set_extra!(factor_data, :test_key, "test_value")
@@ -80,9 +71,9 @@ end
 end
 
 @testitem "FactorNodeData implements get_extra with CompileTimeDictionaryKey" begin
-    import GraphPPL: FactorNodeData, get_extra, set_extra!, CompileTimeDictionaryKey
+    import GraphPPL: FactorNodeData, get_extra, set_extra!, CompileTimeDictionaryKey, create_factor_data
 
-    factor_data = FactorNodeData("test_form")
+    factor_data = create_factor_data(FactorNodeData, functional_form = "test_form")
     string_key = CompileTimeDictionaryKey{:string_key, String}()
     int_key = CompileTimeDictionaryKey{:int_key, Int}()
 
@@ -107,9 +98,9 @@ end
 end
 
 @testitem "FactorNodeData implements set_extra! with Symbol keys" begin
-    import GraphPPL: FactorNodeData, get_extra, set_extra!
+    import GraphPPL: FactorNodeData, get_extra, set_extra!, create_factor_data
 
-    factor_data = FactorNodeData("test_form")
+    factor_data = create_factor_data(FactorNodeData, functional_form = "test_form")
 
     # Set a new extra
     @test set_extra!(factor_data, :test_key, "test_value") == "test_value"
@@ -128,9 +119,9 @@ end
 end
 
 @testitem "FactorNodeData implements set_extra! with CompileTimeDictionaryKey" begin
-    import GraphPPL: FactorNodeData, get_extra, set_extra!, CompileTimeDictionaryKey
+    import GraphPPL: FactorNodeData, get_extra, set_extra!, CompileTimeDictionaryKey, create_factor_data
 
-    factor_data = FactorNodeData("test_form")
+    factor_data = create_factor_data(FactorNodeData, functional_form = "test_form")
     string_key = CompileTimeDictionaryKey{:string_key, String}()
     int_key = CompileTimeDictionaryKey{:int_key, Int}()
 
@@ -147,16 +138,15 @@ end
 end
 
 @testitem "FactorNodeData show method" begin
-    import GraphPPL: FactorNodeData, set_extra!
+    import GraphPPL: FactorNodeData, set_extra!, create_factor_data
 
-    factor_data = FactorNodeData("test_form", "test_context")
+    factor_data = create_factor_data(FactorNodeData, functional_form = "test_form")
     set_extra!(factor_data, :test_key, "test_value")
 
     # Test string representation
     str = sprint(show, factor_data)
     @test occursin("FactorNodeData", str)
     @test occursin("test_form", str)
-    @test occursin("test_context", str)
     @test occursin("test_key", str)
     @test occursin("test_value", str)
 end
@@ -166,21 +156,20 @@ end
         FactorNodeData,
         FactorNodeDataInterface,
         get_functional_form,
-        get_context,
         has_extra,
         get_extra,
         set_extra!,
-        CompileTimeDictionaryKey
+        CompileTimeDictionaryKey,
+        create_factor_data
 
     # Verify FactorNodeData is a subtype of FactorNodeDataInterface
     @test FactorNodeData <: FactorNodeDataInterface
 
     # Create a test instance
-    factor_data = FactorNodeData("test_form", "test_context")
+    factor_data = create_factor_data(FactorNodeData, functional_form = "test_form")
 
     # Test all interface methods are implemented
     @test get_functional_form(factor_data) == "test_form"
-    @test get_context(factor_data) == "test_context"
 
     # Test extras management
     @test !has_extra(factor_data, :test_key)
@@ -196,26 +185,4 @@ end
     @test has_extra(factor_data, key)
     @test get_extra(factor_data, key) == 42
     @test get_extra(factor_data, CompileTimeDictionaryKey{:nonexistent, Float64}(), 3.14) == 3.14
-end
-
-@testitem "create_factor_data function" begin
-    import GraphPPL: FactorNodeData, create_factor_data, get_functional_form, get_context
-
-    # Test basic creation
-    form = "test_form"
-    context = "test_context"
-    factor_data = create_factor_data(FactorNodeData, context, form)
-
-    # Verify the created data has correct form and context
-    @test factor_data isa FactorNodeData
-    @test get_functional_form(factor_data) === form
-    @test get_context(factor_data) === context
-    @test isempty(factor_data.extras)
-
-    # Test with kwargs (should be ignored as per implementation)
-    factor_data_with_kwargs = create_factor_data(FactorNodeData, context, form; extra_param = 42)
-    @test factor_data_with_kwargs isa FactorNodeData
-    @test get_functional_form(factor_data_with_kwargs) === form
-    @test get_context(factor_data_with_kwargs) === context
-    @test isempty(factor_data_with_kwargs.extras)
 end

--- a/test/model/core/variable_node_data_tests.jl
+++ b/test/model/core/variable_node_data_tests.jl
@@ -1,34 +1,16 @@
 
 @testitem "VariableNodeData creation with `create_variable_data`" begin
-    import GraphPPL:
-        VariableNodeData,
-        get_name,
-        get_kind,
-        get_value,
-        get_index,
-        get_link,
-        create_variable_data,
-        VariableNodeKind
+    import GraphPPL: VariableNodeData, get_name, get_kind, get_value, get_index, get_link, create_variable_data, VariableNodeKind
 
     # Test basic creation
-    vnd = create_variable_data(
-        VariableNodeData,
-        name = :test,
-        kind = VariableNodeKind.Random,
-        value = 5
-    )
+    vnd = create_variable_data(VariableNodeData, name = :test, kind = VariableNodeKind.Random, value = 5)
     @test @inferred(get_name(vnd)) === :test
     @test @inferred(get_kind(vnd)) === VariableNodeKind.Random
     @test get_value(vnd) === 5
 
     # Test with all fields
     vnd = create_variable_data(
-        VariableNodeData,
-        name = :full_test,
-        index = 2,
-        link = "some_link",
-        kind = VariableNodeKind.Data,
-        value = 10.5
+        VariableNodeData, name = :full_test, index = 2, link = "some_link", kind = VariableNodeKind.Data, value = 10.5
     )
     @test get_name(vnd) === :full_test
     @test get_index(vnd) === 2
@@ -38,13 +20,7 @@
 end
 
 @testitem "VariableNodeData kind tests" begin
-    import GraphPPL:
-        VariableNodeData,
-        is_random,
-        is_data,
-        is_constant,
-        create_variable_data,
-        VariableNodeKind
+    import GraphPPL: VariableNodeData, is_random, is_data, is_constant, create_variable_data, VariableNodeKind
 
     # Test random variable
     random_var = create_variable_data(VariableNodeData, name = :x, kind = VariableNodeKind.Random)
@@ -72,10 +48,10 @@ end
 end
 
 @testitem "VariableNodeData anonymous test" begin
-    import GraphPPL: VariableNodeData, is_anonymous, create_variable_data
+    import GraphPPL: VariableNodeData, VariableNodeKind, is_anonymous, create_variable_data
 
     # Test anonymous variable
-    anon_var = create_variable_data(VariableNodeData, name = :anonymous_var_graphppl)
+    anon_var = create_variable_data(VariableNodeData, name = :x, kind = VariableNodeKind.Anonymous)
     @test is_anonymous(anon_var) === true
 
     # Test named variable
@@ -205,7 +181,7 @@ end
 end
 
 @testitem "VariableNodeData show method" begin
-    import GraphPPL: VariableNodeData, set_extra!, create_variable_data
+    import GraphPPL: VariableNodeData, VariableNodeKind, set_extra!, create_variable_data
 
     vnd = create_variable_data(VariableNodeData, name = :test, kind = VariableNodeKind.Random)
     set_extra!(vnd, :test_key, "test_value")
@@ -276,6 +252,7 @@ end
 @testitem "test that VariableNodeData methods do not allocate" begin
     import GraphPPL:
         VariableNodeData,
+        create_variable_data,
         get_name,
         get_index,
         get_link,
@@ -288,7 +265,7 @@ end
         has_extra,
         get_extra,
         set_extra!
-    vnd = VariableNodeData(name = :test)
+    vnd = create_variable_data(VariableNodeData, name = :test)
     @test @allocated(get_name(vnd)) == 0
     @test @allocated(get_index(vnd)) == 0
     @test @allocated(get_link(vnd)) == 0
@@ -300,7 +277,6 @@ end
     @test @allocated(is_anonymous(vnd)) == 0
     @test @allocated(has_extra(vnd, :test)) == 0
     @test @allocated(get_extra(vnd, :test, "default")) == 0
-    @test @allocated(get_extra(vnd)) == 0
     set_extra!(vnd, :test, "value")
     @test @allocated(get_extra(vnd, :test)) == 0
 end
@@ -308,38 +284,38 @@ end
 @testitem "create_variable_data interface test" begin
     import GraphPPL:
         VariableNodeData,
+        VariableNodeKind,
+        create_variable_data,
         get_name,
         get_index,
         get_link,
         get_kind,
         get_value,
-        get_context,
         is_random,
         is_data,
         is_constant,
         is_anonymous,
         has_extra,
         get_extra,
-        set_extra!,
-        create_variable_data
+        set_extra!
 
     # Test that create_variable_data works with all arguments
-    vnd = create_variable_data(VariableNodeData, :test_var, 1, :random, "test_link", 42.0, "test_context", Dict(:extra => "metadata"))
+    vnd = create_variable_data(
+        VariableNodeData, name = :test_var, index = 1, kind = VariableNodeKind.Random, link = "test_link", value = 42.0
+    )
 
     @test get_name(vnd) === :test_var
     @test get_index(vnd) === 1
-    @test get_kind(vnd) === :random
+    @test get_kind(vnd) === VariableNodeKind.Random
     @test get_link(vnd) === "test_link"
     @test get_value(vnd) === 42.0
-    @test get_context(vnd) === "test_context"
 
     # Test with minimal arguments
-    vnd_minimal = create_variable_data(VariableNodeData, :minimal_var, nothing, :data, nothing, nothing, nothing)
+    vnd_minimal = create_variable_data(VariableNodeData, name = :minimal_var, kind = VariableNodeKind.Data)
 
     @test get_name(vnd_minimal) === :minimal_var
     @test get_index(vnd_minimal) === nothing
-    @test get_kind(vnd_minimal) === :data
+    @test get_kind(vnd_minimal) === VariableNodeKind.Data
     @test get_link(vnd_minimal) === nothing
     @test get_value(vnd_minimal) === nothing
-    @test get_context(vnd_minimal) === nothing
 end


### PR DESCRIPTION
As from our discussion 

This pull request introduces updates to the interfaces of a factor graph library, focusing on renaming and restructuring core abstractions for edge, factor, and variable node data. The changes aim to improve clarity, extensibility, and type safety in the library's API. Below is a summary of the most important changes grouped by theme.

### Edge Interface Updates
* Renamed `EdgeInterface` to `EdgeDataInterface` and updated all related functions (`get_name`, `get_index`, `has_extra`, etc.) to use the new type. This ensures consistency and better reflects the purpose of the interface.
* Updated the `add_edge!` and `get_edge_data_type` methods in `src/interfaces/model_interface.jl` to use `EdgeDataInterface` instead of `EdgeInterface`. [[1]](diffhunk://#diff-e1c959bfd4bc5ae74ddeecd194b6e11674798e09cd94c7c3a33024d3f2acad10L124-R131) [[2]](diffhunk://#diff-e1c959bfd4bc5ae74ddeecd194b6e11674798e09cd94c7c3a33024d3f2acad10L372-R372)
* Modified the `create_edge_data` function to reflect the new naming convention and clarified its documentation.

### Factor Node Interface Updates
* Updated `FactorNodeDataInterface` to include new functions and renamed parameters for clarity, such as `get_functional_form`, `has_extra`, and `set_extra!`.
* Simplified the `create_factor_data` function to focus on the `functional_form` parameter, removing unused arguments like `context`.

### Variable Node Interface Updates
* Introduced a `VariableNodeKind` module to define constants like `Random`, `Data`, and `Constant` for variable node types. This replaces the previous use of `Symbol` for specifying kinds.
* Added the `is_kind` function and updated existing functions (`is_random`, `is_data`, etc.) to use it for checking variable kinds. [[1]](diffhunk://#diff-83a6a3811115a0fbc1f04fd5876237a0bfeace1f55f6efad0817e9d8ce6ecb6dL75-R78) [[2]](diffhunk://#diff-83a6a3811115a0fbc1f04fd5876237a0bfeace1f55f6efad0817e9d8ce6ecb6dL94-R87) [[3]](diffhunk://#diff-83a6a3811115a0fbc1f04fd5876237a0bfeace1f55f6efad0817e9d8ce6ecb6dL103-R96) [[4]](diffhunk://#diff-83a6a3811115a0fbc1f04fd5876237a0bfeace1f55f6efad0817e9d8ce6ecb6dL112-R124)
* Reintroduced `create_variable_data` with a keyword-based signature for extensibility, aligning it with the new `VariableNodeKind` module.

### Plugin and Model Integration
* Updated the `preprocess_plugin` function to use `EdgeDataInterface` instead of `EdgeInterface`, ensuring compatibility with the new edge data abstraction.
* Updated the `add_edge!` function in `BipartiteModel` to use `EdgeDataInterface`, aligning with the broader interface changes.

These changes enhance the maintainability and usability of the library by adopting clearer abstractions and improving type safety across the API.