### PR TITLE
prevent adding methods to the functions `>` and `>=`

### DIFF
--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -917,12 +917,8 @@ function Base.:(==)(left::VariableRef, right)
 end
 Base.:(==)(left, right::VariableRef) = right == left
 
-Base.:(>)(left::VariableRef, right) = left == right
-Base.:(>)(left, right::VariableRef) = left == right
 Base.:(<)(left::VariableRef, right) = left == right
 Base.:(<)(left, right::VariableRef) = left == right
-Base.:(>=)(left::VariableRef, right) = left == right
-Base.:(>=)(left, right::VariableRef) = left == right
 Base.:(<=)(left::VariableRef, right) = left == right
 Base.:(<=)(left, right::VariableRef) = left == right
 


### PR DESCRIPTION
As documented, the intended way to implement `>` is to add a method to `<`. Similarly with `>=`. A package should never add a method to either `>` or `>=`.