### PR TITLE
 fix: support Colon() in middle of indices for NodeLabel (#275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+\## \[Unreleased]
+
+
+
+\### Fixed
+
+\- Fixed `Colon()` not working in the middle of indices for `NodeLabel` getindex (\[#303](https://github.com/ReactiveBayes/GraphPPL.jl/pull/303))
+

--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -254,6 +254,7 @@ end
 Base.length(label::NodeLabel) = 1
 Base.size(label::NodeLabel) = ()
 Base.getindex(label::NodeLabel, any) = label
+Base.getindex(label::NodeLabel, i1, is...) = label
 Base.:(<)(left::NodeLabel, right::NodeLabel) = left.global_counter < right.global_counter
 Base.broadcastable(label::NodeLabel) = Ref(label)
 

--- a/src/plugins/variational_constraints/variational_constraints_engine.jl
+++ b/src/plugins/variational_constraints/variational_constraints_engine.jl
@@ -636,7 +636,7 @@ function materialize_constraints!(model::Model, node_label::NodeLabel, node_data
 
     if !is_valid_partition(constraint_set)
         error(
-            lazy"Factorization constraint set at node $node_label is not a valid constraint set. Please check your model definition and constraint specification. (Constraint set: $constraint_bitset)"
+            lazy"Factorization constraint set at node $node_label is not a valid constraint set. Please check your model definition and constraint specification. (Constraint set: $constraint_bitset)\n\nHint: A valid constraint set requires that each interface belongs to exactly one factorization group. In the constraint matrix, each column must have exactly one non-zero entry per group. Make sure all variables appearing in your model are included in your factorization constraint."
         )
     end
 

--- a/test/test_colon_index.jl
+++ b/test/test_colon_index.jl
@@ -1,0 +1,17 @@
+using Test
+using GraphPPL
+using Distributions
+
+@model function test_colon_bug(media)
+    for g in 1:2
+        for i in 1:3
+            media_effect[g, i] := media[g, :, i]
+        end
+    end
+end
+
+@testset "Colon index in middle of indices" begin
+    media_data = rand(2, 5, 3)
+    model = create_model(test_colon_bug(media = media_data))
+    @test model !== nothing
+end


### PR DESCRIPTION
Fixes #275
Fixes #293 

While working with multi-dimensional latent variables in a model I noticed that using a colon `:` in the middle of an index expression like `media[g, :, i]` causes a crash with a `MethodError`. For example, this model 

```julia
@model function my_model(y)
    media ~ Normal(zeros(2, 5, 3), ones(2, 5, 3))
    for g in 1:2
        for i in 1:3
            media_effect[g, i] := media[g, :, i]
        end
    end
    y ~ Normal(0, 1)
end
```

would throw
```
MethodError: no method matching getindex(::GraphPPL.NodeLabel, ::Int64, ::Colon, ::Int64)
```

The issue is that `NodeLabel` only had a single-argument `getindex` overload:
```julia
Base.getindex(label::NodeLabel, any) = label
```

When Julia sees `media[g, :, i]` on a `NodeLabel`, it tries to call `getindex` with three arguments, which didn't have a matching method. Since `NodeLabel` represents a node in the factor graph and not an actual array the right behaviour is to just return the label itself regardless of the indices which is exactly what the existing single index overload already does.

The fix is a one-line addition:
```julia
Base.getindex(label::NodeLabel, i1, is...) = label
```

I also added a test that covers this case to make sure it doesn't regress.