### PR TITLE
fix: remove dead `variableref_checked_collection_typeof` (unbound `ref`)

### DIFF
--- a/src/graph_engine.jl
+++ b/src/graph_engine.jl
@@ -1059,10 +1059,6 @@ variable_ref_eltype(::Type{Nothing}, ::Type{Nothing}) = Any
 variable_ref_eltype(::Type{E}, ::Type{L}) where {E, L} = Base.eltype(E)
 variable_ref_eltype(::Type{Nothing}, ::Type{L}) where {L} = Base.eltype(L)
 
-function variableref_checked_collection_typeof(::VariableRef)
-    return variableref_checked_iterator_call(typeof, :typeof, ref)
-end
-
 Base.length(ref::VariableRef) = variableref_checked_iterator_call(Base.length, :length, ref)
 Base.firstindex(ref::VariableRef) = variableref_checked_iterator_call(Base.firstindex, :firstindex, ref)
 Base.lastindex(ref::VariableRef) = variableref_checked_iterator_call(Base.lastindex, :lastindex, ref)


### PR DESCRIPTION
## Description

Fixes #03. `src/graph_engine.jl:1062-1064` defines `variableref_checked_collection_typeof(::VariableRef)`
which references a never-bound `ref` (would `UndefVarError` on any call). The function has no
callers anywhere in the repo, so it is removed.

## Change

Delete the function (and no other code references it, per `grep`).

## Verification

`src/graph_engine.jl` compiles; `grep` for `variableref_checked_collection_typeof` now returns
no definitions.