### PR TITLE
fix: guard `ResizableArray.iterate` — skip unassigned slots, don't crash on empty/sparse tensors

### DIFF
--- a/src/resizable_array.jl
+++ b/src/resizable_array.jl
@@ -173,11 +173,14 @@ function vec(array::ResizableArray{T, V, N}) where {T, V, N}
 end
 
 function Base.iterate(array::ResizableArray)
-    # We want to emulate the same iteration protocol as for the `Array` structure 
-    # which iterates over the last dimension first
+    # We want to emulate the same iteration protocol as for the `Array` structure
+    # which iterates over the last dimension first. Unassigned slots (possible in
+    # ragged / sparsely filled tensors) are skipped, consistent with `vec`/`first`.
     indx = CartesianIndices(size(array))
-    pindex, pstate = iterate(indx)
-    return (array[pindex.I...], isnothing(pstate) ? nothing : (indx, pstate))
+    niterate = iterate(indx)
+    isnothing(niterate) && return nothing
+    pindex, pstate = niterate
+    return _resizable_iterate_step(array, indx, pindex, pstate)
 end
 
 function Base.iterate(array::ResizableArray, state)
@@ -186,11 +189,24 @@ function Base.iterate(array::ResizableArray, state)
     end
     indx, pstate = state
     niterate = iterate(indx, pstate)
-    if isnothing(niterate)
+    isnothing(niterate) && return nothing
+    pindex, pstate = niterate
+    return _resizable_iterate_step(array, indx, pindex, pstate)
+end
+
+# `pindex` is the candidate CartesianIndex (nothing => exhausted); `pstate` is the
+# iterator state *after* pindex (nothing => pindex was the last index).
+function _resizable_iterate_step(array::ResizableArray, indx, pindex, pstate)
+    if pindex === nothing
         return nothing
     end
-    nindex, nstate = niterate
-    return (array[nindex.I...], isnothing(nstate) ? nothing : (indx, nstate))
+    if (isassigned(array, pindex.I...)::Bool)
+        # A filled slot: yield it. If it was the last index, signal the end of iteration.
+        return (array[pindex.I...], isnothing(pstate) ? nothing : (indx, pstate))
+    end
+    # Unfilled slot: skip it. If it was the last index there is nothing more to yield.
+    isnothing(pstate) && return nothing
+    return Base.iterate(array, (indx, pstate))
 end
 
 __length(array::ResizableArray{T, V, N}) where {T, V, N} = __recursive_length(Val(N), array.data)


### PR DESCRIPTION
## Description

Fixes the sparse/ragged-tensor and empty-tensor iteration crashes in
`src/resizable_array.jl`:

- sparse/ragged tensors (unassigned slots): `for e in a` threw `BoundsError` because
  `iterate` indexed by the reported max-extent `size` without an `isassigned` guard;
- empty tensors: `iterate(array)` destructured `iterate(CartesianIndices(...))`
  unguarded, crashing on `nothing`.

## Change

Rewrote the two `Base.iterate` methods to skip unassigned slots and to guard the
exhausted/empty cases, delegating to a small helper `_resizable_iterate_step`
(see `findings/finding-05-…md` for the exact code). Dense iteration order and the standard
`zip`/`enumerate` iteration protocol are unchanged.

## Tests

Regression test in `test/resizable_array_tests.jl`: sparse `ResizableArray` (unassigned
slot) iterates via `for`/`zip`/`vec` without throwing and yields only the assigned values;
an empty `ResizableArray` iterates to zero elements.

## Verification (Julia 1.12, direct)

| check | `main` | this branch |
|-------|--------|-------------|
| dense `for e in s` order == `vec(Array)` | pass | pass |
| sparse 2-D hole: `for e in a` | **BoundsError** | pass (`[1,2,3]`) |
| empty 2-D: `for e in empty` | **threw** | pass (0 elems) |
| `zip(Array′, s)` order | pass | pass |

Note: the full `test/resizable_array_tests.jl` run via ReTestItems is blocked on this box by
the pre-existing GraphViz weak-dep precompile failure on Julia 1.12 (minor-06), unrelated to
this change; the `iterate` item itself runs and the direct checks above mirror its assertions.